### PR TITLE
[ci skip] Fix spelling: justifaction -> justification

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -57,7 +57,7 @@ year = {2007}
 
 @article{Morris1991,
 abstract = {A computational model is a representation of some physical or other system of interest, first expressed mathematically and then implemented in the form of a computer program; it may be viewed as a function of inputs that, when evaluated, produces outputs. Motivation for this article comes from computational models that are deterministic, complicated enough to make classical mathematical analysis impractical and that have a moderate-to-large number of inputs. The problem of designing computational experiments to determine which inputs have important effects on an output is considered. The proposed experimental plans are composed of individually randomized one-factor-at-a-time designs, and data analysis is based on the resulting random sample of observed elementary effects, those changes in an output due solely to changes in a particular input. Advantages of this approach include a lack of reliance on assumptions of relative sparsity of important inputs, monotonicity of outputs with respect to inputs, or adequacy of a low-order polynomial as an approximation to the computational model.},
-annotate = {Contains useful justifaction of distinction of Morris method from LHS and similar methods.},
+annotate = {Contains useful justification of distinction of Morris method from LHS and similar methods.},
 author = {Morris, Max D},
 doi = {10.2307/1269043},
 issn = {0040-1706},


### PR DESCRIPTION
## Summary

This PR fixes a spelling error: justifaction → justification.

## Changes Made

- Fixed the misspelling of justification 
- Fixed in bibliography file

## Notes

-  included to avoid unnecessary CI runs for spelling fixes
- This is a clear spelling error correction