### PR TITLE
Fix SklarDist constructor calls in shapley.md tutorial

### DIFF
--- a/docs/src/tutorials/shapley.md
+++ b/docs/src/tutorials/shapley.md
@@ -97,7 +97,7 @@ Covmat = Matrix(1.0f0 * I, d, d)
 marginals = [Normal(mu[i]) for i in 1:d]
 
 copula = GaussianCopula(Covmat)
-input_distribution = SklarDist(copula, marginals)
+input_distribution = SklarDist(copula, Tuple(marginals))
 
 function batched_loss_n_ode(θ)
     # The copula returns samples of `Float64`s
@@ -144,7 +144,7 @@ end
 
 #since the marginals are standard normal the covariance matrix and correlation matrix are the same
 copula = GaussianCopula(Corrmat)
-input_distribution = SklarDist(copula, marginals)
+input_distribution = SklarDist(copula, Tuple(marginals))
 shapley_effects = gsa(
     batched_loss_n_ode, Shapley(; n_perms = 100, n_var = 100, n_outer = 100),
     input_distribution, batch = true)


### PR DESCRIPTION
## Description
Fixes the documentation build regression in the shapley tutorial caused by a Copulas.jl API change.

## Problem
The `SklarDist` constructor now requires marginals as a tuple instead of a vector, causing doc build failures:
```
MethodError: no method matching Copulas.SklarDist(::Copulas.GaussianCopula{54, Matrix{Float32}}, ::Vector{Distributions.Normal{Float32}})

Closest candidates are:
  Copulas.SklarDist(::Copulas.Copula{d}, !Matched::NTuple{d, Any}) where d
```

## Changes
- Line 100: `SklarDist(copula, marginals)` → `SklarDist(copula, Tuple(marginals))`  
- Line 147: `SklarDist(copula, marginals)` → `SklarDist(copula, Tuple(marginals))`

## Testing
Tested locally - the shapley.md tutorial now builds successfully.

## Related
This fix also applies to PR #198 which is experiencing the same doc build failure.

Fixes https://github.com/SciML/GlobalSensitivity.jl/actions/runs/18372999504/job/52340451471

🤖 Generated with [Claude Code](https://claude.com/claude-code)