### PR TITLE
Documentation improvements: Fix typos, formatting, and missing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ function ishi(X)
 end
 
 n = 600000
-lb = -ones(4) * π
-ub = ones(4) * π
+lb = -ones(3) * π
+ub = ones(3) * π
 sampler = SobolSample()
 A, B = QuasiMonteCarlo.generate_design_matrices(n, lb, ub, sampler)
 

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -13,5 +13,6 @@ pages = [
         "methods/fractional.md",
         "methods/rbdfast.md",
         "methods/rsa.md",
+        "methods/shapley.md",
         "methods/mutualinformation.md"]
 ]

--- a/docs/src/tutorials/shapley.md
+++ b/docs/src/tutorials/shapley.md
@@ -42,7 +42,7 @@ dudt2 = Flux.Chain(x -> x .^ 3,
     Flux.Dense(2, 10, tanh),
     Flux.Dense(10, 2))
 p, re = Flux.destructure(dudt2) # use this p as the initial condition!
-dudt(u, p, t) = re(p)(u) # need to restrcture for backprop!
+dudt(u, p, t) = re(p)(u) # need to restructure for backprop!
 prob = ODEProblem(dudt, u0, tspan)
 
 θ = [u0; p] # the parameter vector to optimize

--- a/src/regression_sensitivity.jl
+++ b/src/regression_sensitivity.jl
@@ -6,7 +6,7 @@
 
 Providing this to `gsa` results in a calculation of the following statistics, provided as a `RegressionGSAResult`. If
 the function `f` to be analyzed is of dimensionality ``f: R^n -> R^m``, then these coefficients
-are returned as a matrix, with the corresponding statistic in the `(i, j)`` entry.
+are returned as a matrix, with the corresponding statistic in the `(i, j)` entry.
 
 - `pearson`: This is equivalent to the correlation coefficient matrix between input and output. The rank version is known as the Spearman coefficient.
 - `standard_regression`: Standard regression coefficients, also known as sigma-normalized derivatives
@@ -58,14 +58,14 @@ If `rank` is set to `true`, then the rank coefficients are also calculated.
 using GlobalSensitivity
 
 function linear_batch(X)
-    A= 7
-    B= 0.1
-    @. A*X[1,:]+B*X[2,:]
+    A = 7
+    B = 0.1
+    @. A * X[1, :] + B * X[2, :]
 end
 function linear(X)
-    A= 7
-    B= 0.1
-    A*X[1]+B*X[2]
+    A = 7
+    B = 0.1
+    A * X[1] + B * X[2]
 end
 
 p_range = [[-1, 1], [-1, 1]]


### PR DESCRIPTION
@ChrisRackauckas 

This PR contains focused documentation improvements found during a systematic review:

## Changes Made

1. **Fixed Ishigami function example in README** (README.md:53-54)
   - Changed parameter count from 4 to 3 to match the actual function implementation
   - The Ishigami function only uses X[1], X[2], and X[3], but the example was creating bounds for 4 parameters

2. **Fixed typo in Shapley tutorial** (docs/src/tutorials/shapley.md:45)
   - "restrcture" → "restructure"

3. **Added missing Shapley method to documentation pages** (docs/pages.jl:16)
   - The shapley.md file exists in methods/ but wasn't listed in the pages array
   - This would cause the Shapley method documentation to not appear in the built docs

4. **Fixed docstring formatting in RegressionGSA** (src/regression_sensitivity.jl:9)
   - Fixed backtick formatting: `(i, j)`` → `(i, j)`

5. **Improved code formatting in RegressionGSA examples** (src/regression_sensitivity.jl:61-68)
   - Added proper spacing around operators for consistency with SciML style
   - `A= 7` → `A = 7`
   - `A*X[1,:]` → `A * X[1, :]`

## Testing

- All changes are documentation-only
- Fixed examples match patterns used elsewhere in the codebase
- No code logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)