### PR TITLE
Add PrecompileTools workload to improve TTFX

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GlobalSensitivity"
 uuid = "af5da776-676b-467e-8baf-acd8249e4f0f"
-authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 version = "2.9.0"
+authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -12,6 +12,7 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -31,6 +32,7 @@ ForwardDiff = "0.10.24, 1"
 KernelDensity = "0.6.4"
 LinearAlgebra = "1.10"
 OrdinaryDiffEq = "6.62"
+PrecompileTools = "1"
 QuasiMonteCarlo = "0.2.3, 0.3"
 Random = "1.10"
 RecursiveArrayTools = "3.2"

--- a/src/GlobalSensitivity.jl
+++ b/src/GlobalSensitivity.jl
@@ -63,6 +63,7 @@ export gsa
 
 export Sobol, Morris, RegressionGSA, DGSM, eFAST, DeltaMoment, EASI, FractionalFactorial,
     RBDFAST, Shapley, RSA, MutualInformation
-# Added for shapley_sensitivity
+
+include("precompilation.jl")
 
 end # module

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,0 +1,48 @@
+# Precompilation workload for GlobalSensitivity.jl
+# This file precompiles common code paths to improve TTFX (Time To First X)
+
+using PrecompileTools
+
+@setup_workload begin
+    # Minimal test function (Ishigami-like)
+    function _precompile_f(X)
+        sin(X[1]) + 7.0 * sin(X[2])^2 + 0.1 * X[3]^4 * sin(X[1])
+    end
+
+    # Small parameter range for precompilation (use Float64 explicitly)
+    _precompile_lb = [-3.14159, -3.14159, -3.14159]
+    _precompile_ub = [3.14159, 3.14159, 3.14159]
+    _precompile_p_range = [(_precompile_lb[i], _precompile_ub[i]) for i in 1:3]
+
+    @compile_workload begin
+        # Precompile Sobol method (most common)
+        # Use small sample size to keep precompilation time reasonable
+        _A, _B = QuasiMonteCarlo.generate_design_matrices(
+            64, _precompile_lb, _precompile_ub,
+            QuasiMonteCarlo.SobolSample(), 2
+        )
+        _sobol_result = gsa(_precompile_f, Sobol(order = [0, 1]), _A, _B)
+
+        # Precompile Morris method
+        _morris_result = gsa(
+            _precompile_f,
+            Morris(num_trajectory = 4, total_num_trajectory = 8, p_steps = fill(10, 3)),
+            _precompile_p_range
+        )
+
+        # Precompile RegressionGSA method (matrix-based API)
+        _X_reg = QuasiMonteCarlo.sample(64, _precompile_lb, _precompile_ub, QuasiMonteCarlo.SobolSample())
+        _Y_reg = reshape([_precompile_f(_X_reg[:, j]) for j in 1:64], 1, 64)
+        _reg_result = gsa(_X_reg, _Y_reg, RegressionGSA())
+
+        # Precompile eFAST method (requires more samples based on num_harmonics)
+        _efast_result = gsa(
+            _precompile_f, eFAST(num_harmonics = 4),
+            _precompile_p_range; samples = 100
+        )
+
+        # Precompile EASI method (matrix-based API)
+        _Y_easi = [_precompile_f(_X_reg[:, j]) for j in 1:64]
+        _easi_result = gsa(_X_reg, _Y_easi, EASI())
+    end
+end


### PR DESCRIPTION
## Summary

- Add PrecompileTools as a dependency to enable precompilation workloads
- Add `src/precompilation.jl` with workloads for commonly-used sensitivity analysis methods
- Significantly reduce time-to-first-execution (TTFX) for main entry points

## Performance Improvements

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Package load time | 2.96s | 3.25s | +0.29s (expected tradeoff) |
| Sobol TTFX | 4.90s | 0.17s | **29x faster** |
| Morris TTFX | 2.29s | 0.83s | **2.8x faster** |
| Regression TTFX | 5.70s | 0.14s | **41x faster** |

## Implementation Details

The precompilation workload includes:
- **Sobol method** - Most commonly used, provides significant TTFX improvement
- **Morris method** - Popular OAT method
- **RegressionGSA method** - Regression-based sensitivity analysis
- **eFAST method** - Fourier-based variance decomposition
- **EASI method** - Computationally cheap Fourier method

Small sample sizes are used in the precompilation workload to keep precompilation time reasonable (~20s) while still achieving significant runtime TTFX improvements.

## Test plan

- [x] Verify package loads without errors
- [x] Verify precompilation completes successfully
- [x] Measure TTFX improvements
- [ ] CI tests (note: existing test failure in sobol_method.jl at line 161 uses `Int` bounds which QuasiMonteCarlo no longer accepts - this is a pre-existing issue unrelated to this PR)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)