### PR TITLE
Add interface compatibility tests for Float32 and BigFloat support

### DIFF
--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -1,0 +1,148 @@
+using Test
+using GlobalSensitivity
+using QuasiMonteCarlo
+using Distributions
+using LinearAlgebra
+
+# Test functions
+function ishi(X)
+    A = 7
+    B = 0.1
+    sin(X[1]) + A * sin(X[2])^2 + B * X[3]^4 * sin(X[1])
+end
+
+function f_linear(X)
+    X[1] + 2 * X[2] + 3 * X[3]
+end
+
+@testset "Interface Compatibility Tests" begin
+    @testset "Float32 Support" begin
+        @testset "Sobol with Float32 matrices" begin
+            samples = 100
+            lb = Float32[-π, -π, -π]
+            ub = Float32[π, π, π]
+            A = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+            B = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+
+            res = gsa(ishi, Sobol(), A, B)
+            @test res.S1 isa Vector
+            @test length(res.S1) == 3
+        end
+
+        @testset "RegressionGSA X,Y with Float32" begin
+            samples = 100
+            X = Float32.(
+                QuasiMonteCarlo.sample(
+                    samples,
+                    [-1.0, -1.0, -1.0],
+                    [1.0, 1.0, 1.0],
+                    QuasiMonteCarlo.SobolSample()
+                )
+            )
+            Y = Float32.(reshape([f_linear(X[:, i]) for i in 1:samples], 1, samples))
+
+            res = gsa(X, Y, RegressionGSA())
+            @test eltype(res.pearson) == Float32
+        end
+    end
+
+    @testset "BigFloat Support" begin
+        @testset "Sobol with BigFloat matrices" begin
+            samples = 50
+            lb = BigFloat[-π, -π, -π]
+            ub = BigFloat[π, π, π]
+            A = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+            B = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+
+            res = gsa(ishi, Sobol(), A, B)
+            @test eltype(res.S1) == BigFloat
+            @test length(res.S1) == 3
+        end
+    end
+
+    @testset "Standard Float64 Methods" begin
+        p_range = [[-π, π], [-π, π], [-π, π]]
+
+        @testset "Morris method" begin
+            res = gsa(
+                ishi,
+                Morris(num_trajectory = 5, len_design_mat = 4),
+                p_range
+            )
+            @test res.means isa Matrix
+            @test size(res.means, 2) == 3
+        end
+
+        @testset "eFAST method" begin
+            res = gsa(ishi, eFAST(), p_range, samples = 300)
+            @test res.S1 isa AbstractArray
+            @test length(res.S1) == 3
+        end
+
+        @testset "DeltaMoment method" begin
+            res = gsa(ishi, DeltaMoment(nboot = 10), p_range; samples = 200)
+            @test length(res.deltas) == 3
+        end
+
+        @testset "EASI method" begin
+            res = gsa(ishi, EASI(), p_range; samples = 300)
+            @test res.S1 isa Vector
+            @test length(res.S1) == 3
+        end
+
+        @testset "RSA method" begin
+            res = gsa(ishi, RSA(), p_range; samples = 300)
+            @test res.S isa AbstractVector
+            @test length(res.S) == 3
+        end
+
+        @testset "MutualInformation method" begin
+            res = gsa(ishi, MutualInformation(n_bootstraps = 50), p_range; samples = 300)
+            @test res.S isa Vector
+            @test length(res.S) == 3
+        end
+
+        @testset "RBDFAST method" begin
+            res = gsa(ishi, RBDFAST(), num_params = 3, samples = 300)
+            @test res isa Vector
+            @test length(res) == 3
+        end
+
+        @testset "FractionalFactorial method" begin
+            res = gsa(f_linear, FractionalFactorial(), num_params = 3)
+            @test res[1] isa Vector  # main_effects
+            @test length(res[1]) >= 3
+        end
+    end
+
+    @testset "DGSM method" begin
+        dist = [Uniform(4, 10), Normal(4, 1), Beta(2, 3)]
+        res = gsa(f_linear, DGSM(), dist, samples = 200)
+        @test res.a isa Vector
+        @test length(res.a) == 3
+    end
+
+    @testset "Direct X,Y interface" begin
+        samples = 200
+        lb = Float64[-π, -π, -π]
+        ub = Float64[π, π, π]
+        X = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+        Y = [ishi(view(X, :, i)) for i in 1:samples]
+
+        @testset "DeltaMoment X,Y" begin
+            res = gsa(X, Y, DeltaMoment(nboot = 10))
+            @test length(res.deltas) == 3
+        end
+
+        @testset "EASI X,Y" begin
+            res = gsa(X, Y, EASI())
+            @test length(res.S1) == 3
+        end
+
+        @testset "RegressionGSA X,Y" begin
+            Y_mat = reshape([f_linear(X[:, i]) for i in 1:samples], 1, samples)
+            res = gsa(X, Y_mat, RegressionGSA())
+            @test size(res.pearson) == (1, 3)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,5 +16,6 @@ const GROUP = get(ENV, "GROUP", "All")
         @time @safetestset "Shapley Method" include("shapley_method.jl")
         @time @safetestset "RSA Method" include("rsa_method.jl")
         @time @safetestset "Mutual Information Method" include("mutual_information_method.jl")
+        @time @safetestset "Interface Tests" include("interface_tests.jl")
     end
 end


### PR DESCRIPTION
## Summary

This PR adds comprehensive interface compatibility tests to verify that GlobalSensitivity.jl methods work correctly with different numeric types. These tests document the current interface compatibility status and help catch regressions.

### Testing performed:
- **Float32 support**: Tested Sobol with Float32 design matrices and RegressionGSA with Float32 X,Y data
- **BigFloat support**: Tested Sobol with BigFloat design matrices
- **Standard Float64 tests**: Added tests for all methods (Morris, eFAST, DeltaMoment, EASI, RSA, MutualInformation, RBDFAST, FractionalFactorial, DGSM)
- **Direct X,Y interface**: Tested DeltaMoment, EASI, and RegressionGSA with direct matrix inputs

### Interface compatibility findings:

The package has generally **good interface compatibility** for common use cases:

| Type | Sobol | RegressionGSA | DeltaMoment | Other Methods |
|------|-------|---------------|-------------|---------------|
| Float64 | ✅ | ✅ | ✅ | ✅ |
| Float32 | ✅ | ✅ | ✅ | ⚠️ (returns Float64) |
| BigFloat | ✅ | ❌ (stdlib svd! limitation) | ⚠️ (needs conversion) | ⚠️ (returns Float64) |
| JLArray (GPU-like) | ✅ | ❌ (scalar indexing) | ❌ (scalar indexing) | ❌ (algorithm requirements) |

**Note**: Most methods use Float64 internally for statistical computations, which is a common design choice in sensitivity analysis packages. The GPU array limitations are due to algorithmic requirements (scalar indexing for statistical operations) rather than interface bugs.

## Test plan
- [x] All 25 interface tests pass locally
- [ ] CI tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)