### PR TITLE
Apply Runic formatting and fix documentation build

### DIFF
--- a/docs/src/tutorials/juliacon21.md
+++ b/docs/src/tutorials/juliacon21.md
@@ -24,7 +24,7 @@ f1 = function (p)
     return [mean(sol[1, :]), maximum(sol[2, :])]
 end
 
-bounds = [[1, 5], [1, 5], [1, 5], [1, 5]]
+bounds = [[1.0, 5.0], [1.0, 5.0], [1.0, 5.0], [1.0, 5.0]]
 
 reg_sens = gsa(f1, RegressionGSA(true), bounds, samples = 200)
 fig = Figure(resolution = (600, 400))

--- a/docs/src/tutorials/parallelized_gsa.md
+++ b/docs/src/tutorials/parallelized_gsa.md
@@ -37,7 +37,7 @@ Now, let's perform a Morris global sensitivity analysis on this model. We specif
 
 ```@example ode
 m = gsa(f1, Morris(total_num_trajectory = 1000, num_trajectory = 150),
-    [[1, 5], [1, 5], [1, 5], [1, 5]])
+    [[1.0, 5.0], [1.0, 5.0], [1.0, 5.0], [1.0, 5.0]])
 ```
 
 Let's get the means and variances from the `MorrisResult` struct.
@@ -65,7 +65,7 @@ scatter(
 For the Sobol method, we can similarly do:
 
 ```@example ode
-m = gsa(f1, Sobol(), [[1, 5], [1, 5], [1, 5], [1, 5]], samples = 1000)
+m = gsa(f1, Sobol(), [[1.0, 5.0], [1.0, 5.0], [1.0, 5.0], [1.0, 5.0]], samples = 1000)
 ```
 
 ## Direct Use of Design Matrices

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -8,11 +8,11 @@ using LinearAlgebra
 function ishi(X)
     A = 7
     B = 0.1
-    sin(X[1]) + A * sin(X[2])^2 + B * X[3]^4 * sin(X[1])
+    return sin(X[1]) + A * sin(X[2])^2 + B * X[3]^4 * sin(X[1])
 end
 
 function f_linear(X)
-    X[1] + 2 * X[2] + 3 * X[3]
+    return X[1] + 2 * X[2] + 3 * X[3]
 end
 
 @testset "Interface Compatibility Tests" begin


### PR DESCRIPTION
## Summary
- Apply Runic formatting to `test/interface_tests.jl` (adds explicit return statements)
- Fix documentation build by using `Float64` bounds instead of `Int` bounds in tutorial documentation
- The QuasiMonteCarlo.jl Sobol sampling now requires Float bounds, which was causing the docs build to fail

## Test plan
- [x] Ran Runic.jl on source and test files
- [x] Verified documentation builds successfully after the fix
- [ ] CI tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)