### PR TITLE
Batch FFT/DCT across all Fourier-based sensitivity methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GlobalSensitivity"
 uuid = "af5da776-676b-467e-8baf-acd8249e4f0f"
-version = "2.11.0"
+version = "2.12.0"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]

--- a/src/eFAST_sensitivity.jl
+++ b/src/eFAST_sensitivity.jl
@@ -178,13 +178,13 @@ function gsa_efast_all_y_analysis(
         ft = rfft(reshape(all_y, nout, samples, num_params), 2)
         buf = Vector{FT}(undef, (samples ÷ 2) - 1)
         for (i, fti) in enumerate(eachslice(ft; dims = 3))
-            fo = first_order[i] = Vector{FT}(undef, nout)
-            to = total_order[i] = Vector{FT}(undef, nout)
+            first_order_i = first_order[i] = Vector{FT}(undef, nout)
+            total_order_i = total_order[i] = Vector{FT}(undef, nout)
             for (j, row) in enumerate(eachrow(fti))
                 map!(abs2, buf, @view(row[2:(samples ÷ 2)]))
                 z = sum(buf)
-                fo[j] = sum(@view(buf[(1:num_harmonics) * Int(omega[1])])) / z
-                to[j] = 1 - sum(@view(buf[1:(omega[1] ÷ 2)])) / z
+                first_order_i[j] = sum(@view(buf[(1:num_harmonics) * Int(omega[1])])) / z
+                total_order_i[j] = 1 - sum(@view(buf[1:(omega[1] ÷ 2)])) / z
             end
         end
     else

--- a/src/eFAST_sensitivity.jl
+++ b/src/eFAST_sensitivity.jl
@@ -171,46 +171,33 @@ function gsa_efast_all_y_analysis(
     ) where {multioutput}
     (; num_harmonics) = method
     FT = float(eltype(all_y))
-    CT = complex(FT)
-    buf = Vector{CT}(undef, samples)
-    fft_buf = @view(buf[2:(samples ÷ 2)])
-    P = plan_fft!(buf)
     if multioutput
-        size_ = size(all_y)
         first_order = Vector{Vector{FT}}(undef, num_params)
         total_order = Vector{Vector{FT}}(undef, num_params)
+        nout = size(all_y, 1)
+        ft = rfft(reshape(all_y, nout, samples, num_params), 2)
+        buf = Vector{FT}(undef, (samples ÷ 2) - 1)
+        for (i, fti) in enumerate(eachslice(ft; dims = 3))
+            fo = first_order[i] = Vector{FT}(undef, nout)
+            to = total_order[i] = Vector{FT}(undef, nout)
+            for (j, row) in enumerate(eachrow(fti))
+                map!(abs2, buf, @view(row[2:(samples ÷ 2)]))
+                z = sum(buf)
+                fo[j] = sum(@view(buf[(1:num_harmonics) * Int(omega[1])])) / z
+                to[j] = 1 - sum(@view(buf[1:(omega[1] ÷ 2)])) / z
+            end
+        end
     else
         first_order = Vector{FT}(undef, num_params)
         total_order = Vector{FT}(undef, num_params)
-    end
-    soffset = 1
-    for i in 1:num_params
-        if !multioutput
-            copyto!(buf, 1, all_y, soffset, samples)
-            P * buf
-            ys = abs2.(fft_buf .* inv(samples))
-            varnce = 2 * sum(ys)
-            first_order[i] = 2 * sum(ys[(1:num_harmonics) * Int(omega[1])]) / varnce
-            total_order[i] = 1 .- 2 * sum(ys[1:(omega[1] ÷ 2)]) / varnce
-        else
-            ys = Vector{Vector{FT}}(undef, size(all_y, 1))
-            varnce = Vector{FT}(undef, size(all_y, 1))
-            for (j, all_y_j) in enumerate(eachrow(all_y))
-                copyto!(buf, 1, all_y_j, soffset, samples)
-                P * buf
-                ys[j] = ysⱼ = abs2.(fft_buf .* inv(samples))
-                varnce[j] = 2 * sum(ysⱼ)
-            end
-            first_order[i] = map(
-                (y, var) -> 2 * sum(y[(1:num_harmonics) * (omega[1])]) ./
-                    var, ys, varnce
-            )
-            total_order[i] = map(
-                (y, var) -> 1 .- 2 * sum(y[1:(omega[1] ÷ 2)]) ./ var, ys,
-                varnce
-            )
+        ft = rfft(reshape(all_y, samples, num_params), 1)
+        buf = Vector{FT}(undef, (samples ÷ 2) - 1)
+        for (i, fti) in enumerate(eachcol(ft))
+            map!(abs2, buf, @view(fti[2:(samples ÷ 2)]))
+            z = sum(buf)
+            first_order[i] = sum(@view(buf[(1:num_harmonics) * Int(omega[1])])) / z
+            total_order[i] = 1 - sum(@view(buf[1:(omega[1] ÷ 2)])) / z
         end
-        soffset += samples
     end
     if isnothing(y_size)
         _first_order = reduce(hcat, first_order)

--- a/src/eFAST_sensitivity.jl
+++ b/src/eFAST_sensitivity.jl
@@ -170,27 +170,35 @@ function gsa_efast_all_y_analysis(
         ::Val{multioutput}
     ) where {multioutput}
     (; num_harmonics) = method
+    FT = float(eltype(all_y))
+    CT = complex(FT)
+    buf = Vector{CT}(undef, samples)
+    fft_buf = @view(buf[2:(samples ÷ 2)])
+    P = plan_fft!(buf)
     if multioutput
         size_ = size(all_y)
-        first_order = Vector{Vector{eltype(all_y)}}(undef, num_params)
-        total_order = Vector{Vector{eltype(all_y)}}(undef, num_params)
+        first_order = Vector{Vector{FT}}(undef, num_params)
+        total_order = Vector{Vector{FT}}(undef, num_params)
     else
-        first_order = Vector{eltype(all_y)}(undef, num_params)
-        total_order = Vector{eltype(all_y)}(undef, num_params)
+        first_order = Vector{FT}(undef, num_params)
+        total_order = Vector{FT}(undef, num_params)
     end
+    soffset = 1
     for i in 1:num_params
         if !multioutput
-            ft = (fft(all_y[((i - 1) * samples + 1):(i * samples)]))[2:(samples ÷ 2)]
-            ys = abs2.(ft .* inv(samples))
+            copyto!(buf, 1, all_y, soffset, samples)
+            P * buf
+            ys = abs2.(fft_buf .* inv(samples))
             varnce = 2 * sum(ys)
             first_order[i] = 2 * sum(ys[(1:num_harmonics) * Int(omega[1])]) / varnce
             total_order[i] = 1 .- 2 * sum(ys[1:(omega[1] ÷ 2)]) / varnce
         else
-            ys = Vector{Vector{eltype(all_y)}}(undef, size(all_y, 1))
-            varnce = Vector{eltype(all_y)}(undef, size(all_y, 1))
-            for j in eachindex(ys)
-                ff = fft(all_y[j, ((i - 1) * samples + 1):(i * samples)])[2:(samples ÷ 2)]
-                ys[j] = ysⱼ = abs2.(ff .* inv(samples))
+            ys = Vector{Vector{FT}}(undef, size(all_y, 1))
+            varnce = Vector{FT}(undef, size(all_y, 1))
+            for (j, all_y_j) in enumerate(eachrow(all_y))
+                copyto!(buf, 1, all_y_j, soffset, samples)
+                P * buf
+                ys[j] = ysⱼ = abs2.(fft_buf .* inv(samples))
                 varnce[j] = 2 * sum(ysⱼ)
             end
             first_order[i] = map(
@@ -202,6 +210,7 @@ function gsa_efast_all_y_analysis(
                 varnce
             )
         end
+        soffset += samples
     end
     if isnothing(y_size)
         _first_order = reduce(hcat, first_order)

--- a/src/easi_sensitivity.jl
+++ b/src/easi_sensitivity.jl
@@ -72,20 +72,27 @@ Code based on the theory presented in
 and the python implementation of EASI in python's Sensitivity Analysis Library ("SALib")
 """
 
-function _permute_outputs(X::AbstractArray, Y::AbstractArray)
-    """
-    Triangular shape permutation of the precomputed inputs
-    """
-    permutation_index = sortperm(X) # non-mutating
-    result = cat(permutation_index[1:2:end], reverse(permutation_index[2:2:end]), dims = 1)
-    return @view Y[result]
-end
-
-function _compute_first_order_fft!(P, buf, permuted_outputs, max_harmonic, samples::Int)
-    copyto!(buf, permuted_outputs)
-    P * buf
-    half_samples = samples ÷ 2
-    return sum(abs2, @view(buf[(begin + 1):min(begin + (half_samples - 1), begin + max_harmonic)])) / sum(abs2, @view(buf[(begin + 1):(begin + half_samples - 1)]))
+function _gather_triangular_permutation!(dest::AbstractVector, perm::Vector{<:Integer}, Y::AbstractArray)
+    #=
+    Apply the triangular-shape permutation (odd-indexed samples forward,
+    even-indexed samples in reverse) to Y using the sort-order vector `perm`,
+    writing the result directly into `dest`.
+    Avoids intermediate allocations
+    =#
+    n = length(perm)
+    j = firstindex(dest) - 1
+    # Odd-indexed entries of perm (1, 3, 5, ...) in forward order
+    for k in 1:2:n
+        j += 1
+        dest[j] = Y[perm[k]]
+    end
+    # Even-indexed entries of perm (2, 4, 6, ...) in reverse order
+    last_even = 2 * (n ÷ 2)
+    for k in last_even:-2:2
+        j += 1
+        dest[j] = Y[perm[k]]
+    end
+    return dest
 end
 
 """
@@ -98,11 +105,6 @@ Pages 188-191,
 ISSN 1364-8152,
 https://doi.org/10.1016/j.envsoft.2012.03.004.
 """
-function _compute_first_order_dct!(P, buf::Vector{<:Real}, permuted_outputs, max_harmonic::Int, samples)
-    copyto!(buf, permuted_outputs)
-    P * buf
-    return sum(abs2, @view(buf[(begin + 1):min(end, begin + max_harmonic)])) / sum(abs2, @view(buf[(begin + 1):end]))
-end
 
 function _unskew_S1(S1::Number, max_harmonic::Integer, samples::Integer)
     """
@@ -117,36 +119,41 @@ function _unskew_S1(S1::Number, max_harmonic::Integer, samples::Integer)
 end
 
 function gsa(X::AbstractArray, Y::AbstractArray, method::EASI)
-
     # K is the number of variables, samples is the number of simulations
     K = size(X, 1)
     samples = size(X, 2)
-    sensitivities = zeros(K)
-    sensitivities_c = zeros(K)
 
-    T = float(eltype(Y))
-    if method.dct_method
-        buf = Vector{T}(undef, samples)
-        P = plan_dct!(buf)
-    else
-        buf = Vector{complex(T)}(undef, samples)
-        P = plan_fft!(buf)
-    end
+    # Reuseable buffers for sorting
+    Yperm = Matrix{eltype(Y)}(undef, samples, K)
+    perm = Vector{Int}(undef, samples)
 
-    for i in 1:K
-        Xi = @view X[i, :]
-
-        if method.dct_method
-            S1 = _compute_first_order_dct!(P, buf, Y[sortperm(Xi)], method.max_harmonic, samples)
-        else
-            Y_reordered = _permute_outputs(Xi, Y)
-            S1 = _compute_first_order_fft!(P, buf, Y_reordered, method.max_harmonic, samples)
+    sensitivities = if method.dct_method
+        for (i, xi) in zip(axes(Yperm, 2), eachrow(X))
+            sortperm!(perm, xi)
+            for (k, pk) in zip(axes(Yperm, 1), perm)
+                Yperm[k, i] = Y[pk]
+            end
         end
-
-        S1_C = _unskew_S1(S1, method.max_harmonic, samples) # get bias-corrected version
-        sensitivities[i] = S1
-        sensitivities_c[i] = S1_C
+        dct_Yperm = dct(Yperm, 1)
+        sensitivities = let max_harmonic = method.max_harmonic
+            map(eachcol(dct_Yperm)) do dcti
+                return sum(abs2, @view(dcti[(begin + 1):min(begin + max_harmonic, end)])) / sum(abs2, @view(dcti[(begin + 1):end]))
+            end
+        end
+    else
+        for (i, xi) in zip(axes(Yperm, 2), eachrow(X))
+            sortperm!(perm, xi)
+            _gather_triangular_permutation!(@view(Yperm[:, i]), perm, Y)
+        end
+        rfft_Yperm = rfft(Yperm, 1)
+        sensitivities = let max_harmonic = method.max_harmonic
+            map(eachcol(rfft_Yperm)) do rffti
+                return sum(abs2, @view(rffti[(begin + 1):min(begin + max_harmonic, end - 1)])) / sum(abs2, @view(rffti[(begin + 1):(end - 1)]))
+            end
+        end
     end
+
+    sensitivities_c = map(s -> _unskew_S1(s, method.max_harmonic, samples), sensitivities)
 
     return EASIResult(sensitivities, sensitivities_c)
 end
@@ -156,17 +163,11 @@ function gsa(f, method::EASI, p_range; samples, batch = false)
     ub = [float(i[2]) for i in p_range]
     X = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
 
-    if batch
-        Y = f(X)
-        multioutput = Y isa AbstractMatrix
+    Y = if batch
+        f(X)
     else
-        Y = [f(X[:, j]) for j in axes(X, 2)]
-        multioutput = !(eltype(Y) <: Number)
-        if eltype(Y) <: RecursiveArrayTools.AbstractVectorOfArray
-            y_size = size(Y[1])
-            Y = vec.(Y)
-            desol = true
-        end
+        [(y = f(x); y isa RecursiveArrayTools.AbstractVectorOfArray ? vec(y) : y) for x in eachcol(X)]
     end
+
     return gsa(X, Y, method)
 end

--- a/src/easi_sensitivity.jl
+++ b/src/easi_sensitivity.jl
@@ -123,7 +123,7 @@ function gsa(X::AbstractArray, Y::AbstractArray, method::EASI)
     K = size(X, 1)
     samples = size(X, 2)
 
-    # Reuseable buffers for sorting
+    # Reusable buffers for sorting
     Yperm = Matrix{eltype(Y)}(undef, samples, K)
     perm = Vector{Int}(undef, samples)
 

--- a/src/easi_sensitivity.jl
+++ b/src/easi_sensitivity.jl
@@ -81,12 +81,11 @@ function _permute_outputs(X::AbstractArray, Y::AbstractArray)
     return @view Y[result]
 end
 
-function _compute_first_order_fft(permuted_outputs, max_harmonic, samples)
-    ft = (fft(permuted_outputs))[2:(samples ÷ 2)]
-    ys = abs2.(ft) .* inv(samples)
-    V = 2 * sum(ys)
-    Vi = 2 * sum(ys[(1:max_harmonic)])
-    return Si = Vi / V
+function _compute_first_order_fft!(P, buf, permuted_outputs, max_harmonic, samples::Int)
+    copyto!(buf, permuted_outputs)
+    P * buf
+    half_samples = samples ÷ 2
+    return sum(abs2, @view(buf[(begin + 1):min(begin + (half_samples - 1), begin + max_harmonic)])) / sum(abs2, @view(buf[(begin + 1):(begin + half_samples - 1)]))
 end
 
 """
@@ -99,11 +98,10 @@ Pages 188-191,
 ISSN 1364-8152,
 https://doi.org/10.1016/j.envsoft.2012.03.004.
 """
-function _compute_first_order_dct(permuted_outputs, max_harmonic, samples)
-    ft = dct(permuted_outputs)[2:end]
-    V = sum(abs2, ft)
-    Vi = sum(abs2, ft[(1:max_harmonic)])
-    return Si = Vi / V
+function _compute_first_order_dct!(P, buf::Vector{<:Real}, permuted_outputs, max_harmonic::Int, samples)
+    copyto!(buf, permuted_outputs)
+    P * buf
+    return sum(abs2, @view(buf[(begin + 1):min(end, begin + max_harmonic)])) / sum(abs2, @view(buf[(begin + 1):end]))
 end
 
 function _unskew_S1(S1::Number, max_harmonic::Integer, samples::Integer)
@@ -126,14 +124,23 @@ function gsa(X::AbstractArray, Y::AbstractArray, method::EASI)
     sensitivities = zeros(K)
     sensitivities_c = zeros(K)
 
+    T = float(eltype(Y))
+    if method.dct_method
+        buf = Vector{T}(undef, samples)
+        P = plan_dct!(buf)
+    else
+        buf = Vector{complex(T)}(undef, samples)
+        P = plan_fft!(buf)
+    end
+
     for i in 1:K
         Xi = @view X[i, :]
 
         if method.dct_method
-            S1 = _compute_first_order_dct(Y[sortperm(Xi)], method.max_harmonic, samples)
+            S1 = _compute_first_order_dct!(P, buf, Y[sortperm(Xi)], method.max_harmonic, samples)
         else
             Y_reordered = _permute_outputs(Xi, Y)
-            S1 = _compute_first_order_fft(Y_reordered, method.max_harmonic, samples)
+            S1 = _compute_first_order_fft!(P, buf, Y_reordered, method.max_harmonic, samples)
         end
 
         S1_C = _unskew_S1(S1, method.max_harmonic, samples) # get bias-corrected version

--- a/src/rbd-fast_sensitivity.jl
+++ b/src/rbd-fast_sensitivity.jl
@@ -82,6 +82,9 @@ function gsa(
     # Iterate over factors
 
     sensitivities = zeros(num_params)
+    CT = complex(float(eltype(Y)))
+    buf = Vector{CT}(undef, samples)
+    P = plan_fft!(buf)
     for i in 1:num_params
         s_order = sortperm(s[i])
         # Order Ys by how they would occur if they were
@@ -89,8 +92,9 @@ function gsa(
         # parametric variable s (not its permutation) increased.
         y_reordered = @view Y[s_order]
 
-        ft = fft(y_reordered)
-        ys = abs2.(ft) ./ samples
+        buf .= y_reordered
+        P * buf
+        ys = abs2.(buf) ./ samples
         V = sum(ys[2:samples])
         Vi = 2 * sum(ys[2:(method.num_harmonics + 1)])
         Si = Vi / V

--- a/src/rbd-fast_sensitivity.jl
+++ b/src/rbd-fast_sensitivity.jl
@@ -73,36 +73,38 @@ function gsa(
     s = [s0[randperm(rng, samples)] for i in 1:num_params]
     x = hcat([0.5 .+ asin.(sin.(s[i])) ./ pi for i in 1:num_params]...)
 
-    # Compute outputs
-    if batch
-        Y = f(x')
+    # Compute outputs (type unstable, therefore we use a function barrier below)
+    Y = if batch
+        f(x')
     else
-        Y = [f(@view x[i, :]) for i in axes(x, 1)]
+        [f(xj) for xj in eachrow(x)]
     end
-    # Iterate over factors
 
-    sensitivities = zeros(num_params)
-    CT = complex(float(eltype(Y)))
-    buf = Vector{CT}(undef, samples)
-    P = plan_fft!(buf)
-    for i in 1:num_params
-        s_order = sortperm(s[i])
-        # Order Ys by how they would occur if they were
-        # monotonically increasing as the
-        # parametric variable s (not its permutation) increased.
-        y_reordered = @view Y[s_order]
+    return _rbdfast_analysis(Y, s, method)
+end
 
-        buf .= y_reordered
-        P * buf
-        ys = abs2.(buf) ./ samples
-        V = sum(ys[2:samples])
-        Vi = 2 * sum(ys[2:(method.num_harmonics + 1)])
-        Si = Vi / V
-        # println(ys)
-        # unskew the sensitivies
-        # lambda = 2*method.num_harmonics/samples
-        # sensitivities[i] = Si - (lambda / (1 - lambda)) * (1-Si)
-        sensitivities[i] = Si
+function _rbdfast_analysis(Y::AbstractVector{<:Real}, s::Vector{<:AbstractVector{<:Real}}, method::RBDFAST)
+    # Build a (samples, num_params) matrix of per-parameter-reordered outputs:
+    # each column holds Y reordered so the corresponding parametric variable
+    # would increase monotonically.
+    samples = length(Y)
+    num_params = length(s)
+    Yperm = Matrix{eltype(Y)}(undef, samples, num_params)
+    perm = Vector{Int}(undef, samples)
+    for (i, si) in zip(axes(Yperm, 2), s)
+        sortperm!(perm, si)
+        for (k, pk) in zip(axes(Yperm, 1), perm)
+            Yperm[k, i] = Y[pk]
+        end
+    end
+    ft = rfft(Yperm, 1)
+
+    sensitivities = let H = method.num_harmonics
+        map(eachcol(ft)) do fti
+            V = 2 * sum(abs2, @view(fti[(begin + 1):(end - 1)])) + abs2(fti[end])
+            Vi = 2 * sum(abs2, @view(fti[(begin + 1):(begin + H)]))
+            return Vi / V
+        end
     end
 
     return sensitivities


### PR DESCRIPTION
## Motivation

The three Fourier-based sensitivity methods (eFAST, EASI, RBD-FAST) all computed FFT/DCT inside per-parameter loops. The original implementation called `fft()` / `dct()` per iteration, which both re-planned the transform and allocated fresh output arrays every call. This PR works through that bottleneck in two layers:

1. **Pre-planned in-place transforms** (initial commits) — replace `fft()` / `dct()` with `plan_fft!` / `plan_dct!` and a reusable buffer.
2. **Single batched multi-dimensional transform** (later commits) — go further: build a `(samples, K)` matrix of per-parameter permuted outputs and issue a single `rfft(matrix, 1)` (or `dct(matrix, 1)`) for all parameters at once. This is the same pattern eFAST already uses.

## Changes by method

| File | What changed |
|------|-------------|
| `src/eFAST_sensitivity.jl` | Batched `rfft` over all parameters via `reshape(all_y, samples, num_params)`. `map!(abs2, buf, ...)` reuses a single buffer for the power spectrum. Handles both single-output and multi-output cases. |
| `src/easi_sensitivity.jl` | Batched `rfft` (FFT path) and `dct` (DCT path) over a `(samples, K)` matrix of per-parameter permuted outputs. New `_gather_triangular_permutation!` writes the triangular interleave directly into a target column, dropping the `cat(...)` allocation from the old `_permute_outputs`. `sortperm!` with a reusable `Vector{Int}` buffer eliminates per-iteration sort allocations. The FFT path switched from complex `fft` to `rfft` (correctness-preserving since the harmonic-power ratio only reads the positive-frequency half). |
| `src/rbd-fast_sensitivity.jl` | Batched `rfft` over a `(samples, num_params)` matrix of per-parameter reordered outputs. `V` is reconstructed from the rfft half-spectrum with the Nyquist bin counted once. Analysis is in a separate `_rbdfast_analysis` method (function barrier) so the inner gather loop specializes on `Y`'s concrete type instead of boxing through the union from the `if batch` branch. |
| `Project.toml` | Bump version to v2.12.0. |

## Test plan

- [x] Full `Pkg.test()` passes (all 14 test sets, including eFAST, EASI, RBD-FAST, and interface tests).
- [x] Local benchmarks confirm allocation reductions across all sample/parameter sizes; modest runtime speedups (FFT was never the dominant cost in EASI/RBD-FAST — `sortperm` is, taking ~15 ms vs the batched rfft's ~1 ms at 50k samples × 10 params).

🤖 Generated with [Claude Code](https://claude.com/claude-code)