### PR TITLE
Fix: pass rng in RBDFAST docstring example and apply SciML style

### DIFF
--- a/src/rbd-fast_sensitivity.jl
+++ b/src/rbd-fast_sensitivity.jl
@@ -25,23 +25,26 @@ sensitivity index of factor `Xi`.
 ### Example
 
 ```julia
+using StableRNGs
+
 function linear_batch(X)
-    A= 7
-    B= 0.1
-    @. A*X[1,:]+B*X[2,:]
+    A = 7
+    B = 0.1
+    @. A * X[1, :] + B * X[2, :]
 end
 function linear(X)
-    A= 7
-    B= 0.1
-    A*X[1]+B*X[2]
+    A = 7
+    B = 0.1
+    A * X[1] + B * X[2]
 end
 
-lb = -ones(4)*π
-ub = ones(4)*π
+lb = -ones(4) * π
+ub = ones(4) * π
 
 rng = StableRNG(123)
-res1 = gsa(linear,GlobalSensitivity.RBDFAST(),num_params = 4, samples=15000)
-res2 = gsa(linear_batch,GlobalSensitivity.RBDFAST(),num_params = 4, batch=true, samples=15000)
+res1 = gsa(linear, GlobalSensitivity.RBDFAST(), num_params = 4, samples = 15000, rng = rng)
+res2 = gsa(linear_batch, GlobalSensitivity.RBDFAST(), num_params = 4, batch = true,
+    samples = 15000, rng = rng)
 ```
 """
 struct RBDFAST <: GSAMethod


### PR DESCRIPTION
## Problem

The docstring example for `RBDFAST` in `src/rbd-fast_sensitivity.jl` defines
`rng = StableRNG(123)` but never passes it to `gsa`. Both calls silently use
`Random.default_rng()` instead, making the example misleading — a reader
would expect `rng` to control the sampling.

Additionally, the example functions do not follow the
[SciML Style Guide](https://github.com/SciML/SciMLStyle) (missing spaces
around operators and after commas).

## Fix

- Pass `rng` explicitly to both `gsa` calls in the example
- Add `using StableRNGs` so the example is self-contained and runnable
- Apply SciML style: spaces around operators (`A = 7`, `A * X[1, :]`),
  spaces after commas, spaces around `=` in keyword arguments

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the contributor guidelines, in particular the
  [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API