### PR TITLE
Fix: Sobol conf_level actually controls CI width (#181)

### DIFF
--- a/src/sobol_sensitivity.jl
+++ b/src/sobol_sensitivity.jl
@@ -353,12 +353,14 @@ function gsa_sobol_all_y_analysis(
         S1 = [[Sᵢ[i] for Sᵢ in Sᵢs] for i in 1:length(Sᵢs[1])]
         ST = [[Tᵢ[i] for Tᵢ in Tᵢs] for i in 1:length(Tᵢs[1])]
 
-        function calc_ci(x, mean = nothing)
-            alpha = (1 - method.conf_level)
-            return std(x, mean = mean) / sqrt(length(x))
+        S1_mean = map(mean, S1)
+        ST_mean = map(mean, ST)
+
+        calc_ci = let z = quantile(Normal(0.0, 1.0), (1 + method.conf_level) / 2)
+            (x, mean) -> z * std(x; mean) / sqrt(length(x))
         end
-        S1_CI = map(calc_ci, S1)
-        ST_CI = map(calc_ci, ST)
+        S1_CI = map(calc_ci, S1, S1_mean)
+        ST_CI = map(calc_ci, ST, ST_mean)
 
         if 2 in method.order
             size__ = size(Sᵢⱼs[1])
@@ -373,8 +375,8 @@ function gsa_sobol_all_y_analysis(
                 S2_CI[i] = calc_ci(b, b̄)
             end
         end
-        Sᵢ = reshape(mean.(S1), size_...)
-        Tᵢ = reshape(mean.(ST), size_...)
+        Sᵢ = reshape(S1_mean, size_...)
+        Tᵢ = reshape(ST_mean, size_...)
     else
         Sᵢ = Sᵢs[1]
         Tᵢ = Tᵢs[1]

--- a/test/sobol_method.jl
+++ b/test/sobol_method.jl
@@ -72,7 +72,7 @@ res1 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20), A, B)
 
 # issue #181
 @testset "CI" begin
-    res80 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20, conf_level = 0.80), A, B)
+    res80 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20, conf_level = 0.8), A, B)
     res95 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20, conf_level = 0.95), A, B)
     res99 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20, conf_level = 0.99), A, B)
 
@@ -93,7 +93,7 @@ res1 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20), A, B)
 
     # Actually, the only thing changing is the z-multiplier,
     # so the normalized standard error estimates across runs must equal
-    z80 = quantile(Normal(0.0, 1.0), (1 + 0.80) / 2)
+    z80 = quantile(Normal(0.0, 1.0), (1 + 0.8) / 2)
     z95 = quantile(Normal(0.0, 1.0), (1 + 0.95) / 2)
     z99 = quantile(Normal(0.0, 1.0), (1 + 0.99) / 2)
     @test res80.S1_Conf_Int ./ z80 ≈ res95.S1_Conf_Int ./ z95

--- a/test/sobol_method.jl
+++ b/test/sobol_method.jl
@@ -1,4 +1,5 @@
 using GlobalSensitivity, QuasiMonteCarlo, Test, OrdinaryDiffEq
+using Distributions: Normal, quantile
 
 function ishi_batch(X)
     A = 7
@@ -52,22 +53,56 @@ res1 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20), A, B)
     0.0 0.0 0.0 -7.998213172266514e-7; 0.0 0.0 0.0 0.0
 ] atol = 1.0e-4
 @test res1.S1_Conf_Int ≈ [
-    0.00013100970128286063,
-    0.00014730548523359544,
-    7.398816006175431e-5,
+    0.00025677429613976373,
+    0.0002887134457830459,
+    0.00014501412900342335,
     0.0,
-] atol = 1.0e-4
+] atol = 1.0e-6
 @test res1.ST_Conf_Int ≈ [
-    5.657364947147881e-5,
-    0.00015856915718858496,
-    0.00012283019177515212,
+    0.0001223019032979223,
+    0.00025743925490551845,
+    0.00018012100786659994,
     0.0,
-] atol = 1.0e-4
+] atol = 1.0e-6
 @test res1.S2_Conf_Int ≈ [
-    0.0 0.00019922618025106458 0.00017554669020070315 0.00020712452452973623;
-    0.0 0.0 0.00010571366158995006 0.00010243796353601678;
-    0.0 0.0 0.0 8.791383305689058e-5; 0.0 0.0 0.0 0.0
-] atol = 1.0e-4
+    0.0 0.00039047613806956837 0.00034406519039858785 0.00040595660839326563;
+    0.0 0.0 0.0002071949693901681 0.00020077471918021318;
+    0.0 0.0 0.0 0.00017230794653437235; 0.0 0.0 0.0 0.0
+] atol = 1.0e-6
+
+# issue #181
+@testset "CI" begin
+    res80 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20, conf_level = 0.80), A, B)
+    res95 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20, conf_level = 0.95), A, B)
+    res99 = gsa(ishi, Sobol(order = [0, 1, 2], nboot = 20, conf_level = 0.99), A, B)
+
+    # Point estimates do not depend on conf_level
+    @test res80.S1 == res95.S1 == res99.S1
+    @test res80.ST == res95.ST == res99.ST
+    @test res80.S2 == res95.S2 == res99.S2
+
+    # Confidence intervals depend on confidence levels
+    @test res80.S1_Conf_Int != res95.S1_Conf_Int
+    @test res80.ST_Conf_Int != res95.ST_Conf_Int
+    @test res80.S2_Conf_Int != res95.S2_Conf_Int
+
+    # Wider intervals for higher confidence levels
+    @test all(res80.S1_Conf_Int .≤ res95.S1_Conf_Int .≤ res99.S1_Conf_Int)
+    @test all(res80.ST_Conf_Int .≤ res95.ST_Conf_Int .≤ res99.ST_Conf_Int)
+    @test all(res80.S2_Conf_Int .≤ res95.S2_Conf_Int .≤ res99.S2_Conf_Int)
+
+    # Actually, the only thing changing is the z-multiplier,
+    # so the normalized standard error estimates across runs must equal
+    z80 = quantile(Normal(0.0, 1.0), (1 + 0.80) / 2)
+    z95 = quantile(Normal(0.0, 1.0), (1 + 0.95) / 2)
+    z99 = quantile(Normal(0.0, 1.0), (1 + 0.99) / 2)
+    @test res80.S1_Conf_Int ./ z80 ≈ res95.S1_Conf_Int ./ z95
+    @test res80.S1_Conf_Int ./ z80 ≈ res99.S1_Conf_Int ./ z99
+    @test res80.ST_Conf_Int ./ z80 ≈ res95.ST_Conf_Int ./ z95
+    @test res80.ST_Conf_Int ./ z80 ≈ res99.ST_Conf_Int ./ z99
+    @test res80.S2_Conf_Int ./ z80 ≈ res95.S2_Conf_Int ./ z95
+    @test res80.S2_Conf_Int ./ z80 ≈ res99.S2_Conf_Int ./ z99
+end
 
 res1 = gsa(linear, Sobol(), A, B)
 res2 = gsa(linear_batch, Sobol(), A, B, batch = true)


### PR DESCRIPTION
Fixes #181.

## The bug

`Sobol(; conf_level = ...)` was silently ignored. In `src/sobol_sensitivity.jl`, `calc_ci` computed `alpha = (1 - conf_level)` and then immediately discarded it, returning the bare standard error of the mean:

```julia
function calc_ci(x, mean = nothing)
    alpha = (1 - method.conf_level)            # computed…
    return std(x, mean = mean) / sqrt(length(x))  # …never used
end
```

Every reported Sobol CI therefore had the same width as a ~68% normal-approximation interval (`z ≈ 1`), regardless of the requested level. Changing `conf_level` from `0.80` to `0.99` produced identical numbers.

## The fix

Multiply by `quantile(Normal(0, 1), (1 + conf_level) / 2)` so the requested level actually drives the width. This matches the existing `DeltaMoment` convention (`src/delta_sensitivity.jl:155`). No new dependencies — `Distributions` is already `using`'d at the package level.

Small incidentals bundled in the same commit:
- Precompute `S1_mean` / `ST_mean` once and reuse them both for CI centering (`std(x; mean)`) and the returned point estimates `Sᵢ, Tᵢ`, removing a double `mean` computation.
- Hoist the `z` quantile out of the per-index closure with `let z = …`.

## Tests

- Updated the hardcoded `S1_Conf_Int`, `ST_Conf_Int`, `S2_Conf_Int` expected arrays in `test/sobol_method.jl` to the corrected values, and tightened `atol` from `1e-4` to `1e-6`. While doing this I noticed `ST_Conf_Int`'s prior expectations had already silently drifted from what the current code was actually producing (the loose tolerance was hiding it) — tightening to `1e-6` will prevent that kind of drift from recurring.
- Added a `@testset "CI"` that runs Sobol at `conf_level ∈ {0.80, 0.95, 0.99}` on the same A, B and asserts:
  1. Point estimates `S1`, `ST`, `S2` are identical across the three runs.
  2. CIs differ across the three runs.
  3. CIs are monotonically nondecreasing in `conf_level`.
  4. `res_i ./ z_i ≈ res_j ./ z_j` — i.e. the de-normalized standard error estimates are identical, which is the strongest possible check that `conf_level` is wired through as exactly the normal-quantile multiplier and nothing else.

Local run: `test/sobol_method.jl` passes, `CI | Pass 15/15`.

## Open design question: Wald vs. percentile CIs

While investigating this, we discussed whether the right fix is to keep the Wald-style normal-approximation CI (what this PR does) or to switch to empirical percentile CIs on the bootstrap distribution. Sketch of the trade-offs:

- **Wald CI on the mean** (this PR): `mean(Ŝ_k) ± z_{α/2} · std(Ŝ_k) / √nboot`. Symmetric, always contains the mean, width shrinks with `nboot` since it's a CI on the mean of `nboot` block-level estimators. Matches `DeltaMoment`. Smallest, least disruptive fix; `SobolResult` layout unchanged.
- **Empirical percentile CI**: `[quantile(Ŝ_k, α/2), quantile(Ŝ_k, 1 - α/2)]`. More honest about asymmetry — Sobol indices near `0` or `1` have skewed sampling distributions and a symmetric Wald CI can leak past natural bounds (e.g. a lower bound below 0 for a non-negative index). Downsides: (a) the mean can fall outside the CI for heavily skewed distributions with small `nboot`, and (b) requires a breaking change to `SobolResult` — it would need separate `_Low` / `_High` fields like `DeltaMoment` already uses for `adjusted_deltas_low` / `adjusted_deltas_hi`, instead of the current single `_Conf_Int` half-width.
- **SALib convention** (normal approximation without `√nboot`): `Ŝ ± z · std(bootstrap)`. Used by SALib because its "bootstrap" resamples the full sample with replacement and treats each sample as a direct estimator of the index. Not applicable here because this package's "bootstrap" is actually block-based — `A, B` are sliced into `nboot` disjoint chunks and the reported point estimate is `mean(Ŝ_k)` — so `std/√nboot` is the correct SE for *that* quantity.

Going with the Wald approach for this PR because it's minimally disruptive, matches the in-package convention, and fully resolves #181. Happy to follow up with a `ci_method = :normal | :percentile` kwarg (or a breaking switch to percentile CIs on a minor version bump) if reviewers prefer the percentile convention.

## Also noted, out of scope

`conf_level` is somewhat non-standard naming. Across the broader ecosystem — JuliaStats (e.g. `HypothesisTests.confint(...; level = ...)`), R, Python/SALib — the common spelling is simply `level`. Since `conf_level` is currently consistent across `Sobol`, `DeltaMoment`, and `MutualInformation` in this package, any rename should be a separate deprecation PR touching all three — deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)