### PR TITLE
Refactor omega assignment logic in eFAST_sensitivity.jl

### DIFF
--- a/src/eFAST_sensitivity.jl
+++ b/src/eFAST_sensitivity.jl
@@ -88,10 +88,13 @@ function gsa(
         dists = p_range
     end
 
-    if m >= num_params - 1
-        append!(omega, floor.(Int, collect(range(1, stop = m, length = num_params - 1))))
+    n_comp = num_params - 1
+    if n_comp == 1
+        append!(omega, [1])          # single complementary param → assign frequency 1
+    elseif m >= n_comp
+        append!(omega, floor.(Int, collect(range(1, stop = m, length = n_comp))))
     else
-        append!(omega, collect(range(0, stop = num_params - 2)) .% m .+ 1)
+        append!(omega, collect(range(0, stop = n_comp - 1)) .% m .+ 1)
     end
 
     omega_temp = similar(omega)


### PR DESCRIPTION
Fix bug that is exposed (at minimum) when num_params=2 and samples is either 50 or 500. See #229

## Checklist

- [ ] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This is a bug fix. #229 details two cases of how the bug could be reproduced.