### PR TITLE
Fix Shapley docs broken by SciMLBase v3 ensemble API (closes #231)

### DIFF
--- a/docs/src/tutorials/shapley.md
+++ b/docs/src/tutorials/shapley.md
@@ -101,8 +101,8 @@ input_distribution = SklarDist(copula, marginals)
 function batched_loss_n_ode(θ)
     # The copula returns samples of `Float64`s
     θ = convert(AbstractArray{Float32}, θ)
-    prob_func(prob, i, repeat) = remake(prob; u0 = θ[1:2, i], p = θ[3:end, i])
-    output_func(sol, i) = (sum(abs2, ode_data .- Matrix(sol)), false)
+    prob_func(prob, ctx) = remake(prob; u0 = θ[1:2, ctx.sim_id], p = θ[3:end, ctx.sim_id])
+    output_func(sol, ctx) = (sum(abs2, ode_data .- Matrix(sol)), false)
     ensemble_prob = EnsembleProblem(prob; prob_func, output_func)
     out = solve(
         ensemble_prob, Tsit5(), EnsembleThreads(); saveat = t, trajectories = size(θ, 2))

--- a/src/shapley_sensitivity.jl
+++ b/src/shapley_sensitivity.jl
@@ -26,7 +26,7 @@ we use Copulas.jl to define the joint input distribution as a SklarDist.
 ### Example
 
 ```julia
-using Copulas, Distributions, GlobalSensitivity
+using Copulas, Distributions, GlobalSensitivity, LinearAlgebra
 
 function ishi(X)
     A = 7


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

Fixes two doc problems reported in #231.

1. **`src/shapley_sensitivity.jl` docstring**: the example used `Matrix(I, dim, dim)` but didn't import `LinearAlgebra`, so copy-pasting it threw `UndefVarError: I not defined`. Added `LinearAlgebra` to the `using` line.
2. **`docs/src/tutorials/shapley.md` (Neural ODE example)**: `prob_func` and `output_func` used the old `(prob, i, repeat)` / `(sol, i)` signatures. In SciMLBase v3, `EnsembleProblem` calls them as `prob_func(prob, ctx::EnsembleContext)` and `output_func(sol, ctx)`. Updated both to use `ctx.sim_id`.

## Verification

- Ran the full updated docstring example (both `non-batch`, `batch`, and the correlated-inputs case) end-to-end — completes and prints Shapley effects without error.
- Ran a minimal repro using the new `prob_func(prob, ctx)` signature with an `EnsembleProblem` + `Shapley` (random version) — runs to completion.
- The user's stack trace shows `prob.prob_func(_prob, ctx::EnsembleContext)` in SciMLBase v3.16.0 `basic_ensemble_solve.jl:404`; confirmed in source. The new API has been the only path in SciMLBase v3.x (no arity-detection fallback).

## Test plan

- [ ] Documenter build of the `shapley` tutorial succeeds in CI