### PR TITLE
CI: fix Downgrade group GSA -> Core for SciMLTesting folder mode

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         group:
-          - GSA
+          - Core
         julia-version: ['lts']
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:


### PR DESCRIPTION
## Problem

The `Downgrade` job on `master` is red. It errors before running any tests:

```
ERROR: LoadError: ArgumentError: run_tests (folder mode): GROUP="GSA" is not
"All"/"Core"/"QA" and is not a group declared in test_groups.toml
(declared: ["Core", "QA"]). Add it to test_groups.toml or fix the GROUP value.
```

## Root cause

After the migration to SciMLTesting v1.2 folder-based `run_tests` (#240), `test/runtests.jl` is just `run_tests()` and `test/test_groups.toml` declares only the `Core` and `QA` groups. In folder mode, `run_tests()` rejects any `GROUP` value that is not `All`/`Core`/`QA` or a declared group.

The standalone `.github/workflows/Downgrade.yml` was never updated as part of that migration — it still hardcodes the legacy group value `GSA` in its matrix, which is no longer a valid group. The main `Tests.yml` is fine because it uses the centralized `grouped-tests.yml@v1`, which derives groups from `test_groups.toml`.

## Fix

Change the Downgrade matrix group from `GSA` to `Core`. This matches the canonical pattern in the other converted SciML repos (e.g. `Integrals.jl`, `QuasiMonteCarlo.jl`), which use `group: Core` with `julia-version: ['lts']` for their downgrade job.

## Local verification

Reproduced both behaviors against the real SciMLTesting v1.2 group-resolution gate on Julia 1.10 (the package's [compat] julia floor) using the repo's actual `test/test_groups.toml`:

- `GROUP=GSA` -> reproduces the exact CI `ArgumentError` above.
- `GROUP=Core` -> passes the group-resolution gate and routes to the Core folder run (the same path the green `Tests.yml` Core/lts job already exercises).

Diff is a single line: `GSA` -> `Core`.

Please ignore until reviewed by @ChrisRackauckas.
