### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ GlobalSensitivity = {path = "../.."}
 [compat]
 Aqua = "0.8"
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,12 +1,23 @@
-using GlobalSensitivity, Aqua, Test
-@testset "Aqua" begin
-    Aqua.find_persistent_tasks_deps(GlobalSensitivity)
-    Aqua.test_ambiguities(GlobalSensitivity, recursive = false)
-    Aqua.test_deps_compat(GlobalSensitivity, check_extras = false)
-    @test_broken false  # Aqua deps_compat: missing [compat] entry for Pkg extra — see https://github.com/SciML/GlobalSensitivity.jl/issues/239
-    Aqua.test_piracies(GlobalSensitivity)
-    Aqua.test_project_extras(GlobalSensitivity)
-    Aqua.test_stale_deps(GlobalSensitivity)
-    Aqua.test_unbound_args(GlobalSensitivity)
-    Aqua.test_undefined_exports(GlobalSensitivity)
-end
+using SciMLTesting, GlobalSensitivity, Test
+run_qa(
+    GlobalSensitivity;
+    explicit_imports = true,
+    aqua_kwargs = (; ambiguities = (; recursive = false)),
+    ei_kwargs = (;
+        # OtherPkg-non-public names accessed qualified (e.g. `Random.default_rng`);
+        # de-facto public, just not yet declared `public` upstream.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :default_rng,              # Random
+                :generate_design_matrices, # QuasiMonteCarlo
+                :sample,                   # QuasiMonteCarlo
+                :gradient,                 # ForwardDiff
+                :hessian,                  # ForwardDiff
+            ),
+        ),
+    ),
+    # Heavy `using Statistics/Distributions/...` implicit imports; making each
+    # explicit is a large, mechanical refactor — tracked in
+    # https://github.com/SciML/GlobalSensitivity.jl/issues/245
+    ei_broken = (:no_implicit_imports,)
+)


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the hand-rolled Aqua `test/qa/qa.jl` to the SciMLTesting 1.6 `run_qa` form and enables ExplicitImports.

## What changed

- `test/qa/qa.jl`: now `run_qa(GlobalSensitivity; explicit_imports = true, ...)`. The per-repo Aqua tweak `ambiguities = (; recursive = false)` is preserved via `aqua_kwargs`.
- `test/qa/Project.toml`: `SciMLTesting` compat -> `"1.6"`. `Aqua` kept as a direct test dep because `Aqua.test_ambiguities` spawns a child process that does `using Aqua` (it must be a direct dep, not just transitive via SciMLTesting). `ExplicitImports` is not added (transitive via SciMLTesting).

## ExplicitImports findings (`explicit_imports = true`)

Run locally on Julia 1.10 against released SciMLTesting 1.6.0. 5 of 6 checks pass:

- `no_stale_explicit_imports` — pass
- `all_explicit_imports_via_owners` — pass
- `all_qualified_accesses_via_owners` — pass
- `all_explicit_imports_are_public` — pass
- `all_qualified_accesses_are_public` — pass **with ignores** for five de-facto-public names that other packages access qualified but have not yet declared `public` upstream: `Random.default_rng`; `QuasiMonteCarlo.generate_design_matrices`/`sample`; `ForwardDiff.gradient`/`hessian`. Each ignore documents its source package inline.
- `no_implicit_imports` — **broken** (`ei_broken = (:no_implicit_imports,)`). The module relies on ~46 implicitly-imported names from heavy bare `using Statistics, Distributions, ...`. Making each explicit is a large mechanical refactor; tracked in #245. The marker auto-flags an `Unexpected Pass` once fixed.

## Aqua

The previous `@test_broken false # deps_compat: missing [compat] entry for Pkg extra` (#239) is **resolved**, not carried forward: the offending `Pkg` extra is gone from the root Project.toml, and `Aqua.test_all` now passes with the default `check_extras = true`. So no `aqua_broken` is needed (FIX over BROKEN), and the prior `check_extras = false` workaround is dropped.

## Verification

Local QA group on Julia 1.10 against released SciMLTesting 1.6.0:

```
Test Summary:     | Pass  Broken  Total   Time
Quality Assurance |   16       1     17  33.5s
```

0 fail / 0 error; the single Broken is the tracked `no_implicit_imports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)