### PR TITLE
Bump version to 2.12.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GlobalSensitivity"
 uuid = "af5da776-676b-467e-8baf-acd8249e4f0f"
-version = "2.12.1"
+version = "2.12.2"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (2.12.1 -> 2.12.2) to release unreleased commits on `master` via JuliaRegistrator.