### PR TITLE
Document GlobalSensitivity module public binding

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,6 +21,7 @@ Note: GlobalSensitivity.jl is unrelated to the GlobalSensitivityAnalysis.jl pack
 The general interface for performing global sensitivity analysis using this package is:
 
 ```@docs
+GlobalSensitivity
 gsa(f, method::GlobalSensitivity.GSAMethod, param_range; samples, batch = false)
 ```
 

--- a/src/GlobalSensitivity.jl
+++ b/src/GlobalSensitivity.jl
@@ -1,3 +1,13 @@
+"""
+    GlobalSensitivity
+
+Global sensitivity analysis methods for quantifying how model inputs contribute to
+output uncertainty.
+
+Use [`gsa`](@ref) with method objects such as [`Sobol`](@ref), [`Morris`](@ref),
+or [`RegressionGSA`](@ref) to estimate sensitivity indices from model evaluations
+or precomputed design matrices.
+"""
 module GlobalSensitivity
 
 using Statistics, RecursiveArrayTools, LinearAlgebra, Random


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Add a source docstring for the exported `GlobalSensitivity` module binding.
- Include `GlobalSensitivity` in the rendered index `@docs` block so public API documentation coverage includes the module binding.

## Validation
- `julia --project=. -e 'using GlobalSensitivity; publics = sort(String.(names(GlobalSensitivity; all=false, imported=false))); missing = String[]; for s in publics; sym = Symbol(s); Docs.hasdoc(GlobalSensitivity, sym) || push!(missing, s); end; println("missing source docstrings: ", isempty(missing) ? "none" : join(missing, ", ")); isempty(missing) || exit(1)'`\n- `julia -m Runic --check src/GlobalSensitivity.jl`\n- `git diff --check`\n- `julia --project=docs docs/make.jl`\n- `julia --project=test/qa -e 'using Pkg; Pkg.instantiate(); include("test/qa/qa.jl")'`\n- `timeout 3600 julia --project=. -e 'using Pkg; Pkg.test()'`