### PR TITLE
Release prep: bump GlobalSensitivity to 2.12.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GlobalSensitivity"
 uuid = "af5da776-676b-467e-8baf-acd8249e4f0f"
-version = "2.12.2"
+version = "2.12.3"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release to register the accumulated docstring/QA/test-scaffolding changes since 2.12.2 (module docstring, test-only SciMLTesting compat bump); no functional changes.