### PR TITLE
Fix Morris results when parameters are unsampled

### DIFF
--- a/src/morris_sensitivity.jl
+++ b/src/morris_sensitivity.jl
@@ -204,16 +204,15 @@ function gsa(
                     elem_effect = y1 isa Number ? effect : mean(effect, dims = 2)
                 end
             end
-            if length(effects) >= change_index && change_index > 0
-                push!(effects[change_index], elem_effect)
-            elseif change_index > 0
-                while (length(effects) < change_index - 1)
-                    push!(effects, typeof(elem_effect)[])
+            if change_index > 0
+                if isempty(effects)
+                    effects = [typeof(elem_effect)[] for _ in eachindex(p_range)]
                 end
-                push!(effects, [elem_effect])
+                push!(effects[change_index], elem_effect)
             end
         end
     end
+    effect_prototype = first(Iterators.flatten(effects))
     means = eltype(effects[1])[]
     means_star = eltype(effects[1])[]
     variances = eltype(effects[1])[]
@@ -223,9 +222,9 @@ function gsa(
             push!(means_star, mean(x -> abs.(x), k))
             push!(variances, var(k))
         else
-            push!(means, zero(effects[1][1]))
-            push!(means_star, zero(effects[1][1]))
-            push!(variances, zero(effects[1][1]))
+            push!(means, zero(effect_prototype))
+            push!(means_star, zero(effect_prototype))
+            push!(variances, zero(effect_prototype))
         end
     end
     if desol

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -3,6 +3,7 @@ using GlobalSensitivity
 using QuasiMonteCarlo
 using Distributions
 using LinearAlgebra
+using StableRNGs
 
 # Test functions
 function ishi(X)
@@ -67,10 +68,13 @@ end
             res = gsa(
                 ishi,
                 Morris(num_trajectory = 5, len_design_mat = 4),
-                p_range
+                p_range;
+                rng = StableRNG(652)
             )
             @test res.means isa Matrix
             @test size(res.means, 2) == 3
+            @test length(res.elementary_effects) == 3
+            @test isempty(res.elementary_effects[1])
         end
 
         @testset "eFAST method" begin


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- allocate one Morris elementary-effect bucket per input parameter
- preserve the output dimensions when a randomized design does not sample a parameter
- use the first observed effect as the zero prototype, rather than assuming parameter 1 was sampled
- add a deterministic regression where the first parameter is unsampled

## Cause

`gsa(..., Morris(...))` grew `effects` only through the largest parameter index encountered in the sampled trajectories. This could omit trailing parameters entirely. It also used `effects[1][1]` as the zero prototype, which raised a `BoundsError` when the first parameter was unsampled even if later parameters had effects.

The underlying behavior dates to `ac17789`; `cf53d40` later added the interface test that exposed the result-dimension failure in current CI.

## Verification

I ran the following locally after the final test seed change:

- `GROUP=Core julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`: passed, including `Core/interface_tests.jl` 27/27 and `Core/morris_method.jl` 23/23
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: passed, 17 pass and 1 pre-existing broken test
- `julia +1.12 -m Runic --check .`: passed

The deterministic `StableRNG(652)` case produces three result buckets with the first bucket empty, directly covering the previous invalid-prototype path.

## Automated worklog

1. Reproduced the failing default-branch Core group and isolated the Morris result construction.
2. Traced the original result-vector behavior to `ac17789` and the visible CI regression coverage to `cf53d40`.
3. Preallocated effect buckets and derived zeros from an actually observed effect.
4. Scanned deterministic StableRNG seeds to cover an unsampled first parameter, then reran Core, QA, and Runic.

Co-authored-by trailer is included in the commit as required.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.