### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,7 @@ using SciMLTesting, GlobalSensitivity, Test
 run_qa(
     GlobalSensitivity;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; ambiguities = (; recursive = false)),
     ei_kwargs = (;
         # OtherPkg-non-public names accessed qualified (e.g. `Random.default_rng`);


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public API docs QA via `api_docs_kwargs = (; rendered = true)`.
- Keep the change scoped to the QA invocation; exported package-owned API docstrings and rendered `@docs` entries were already present.
- Do not add `[sources]` or path source entries to tracked project files.

## Validation
- `git diff --check`
- `julia +1.10` via juliaup shim, Runic.jl formatter check on `test/qa/qa.jl`
- `julia +1.10 --project=docs docs/make.jl`
- `julia +1.10 --project=test/qa test/qa/qa.jl` (16 pass, 1 expected broken)
- `julia +1.10 --project=. -e 'using Pkg; Pkg.test(; test_args = ["QA"])'` passed, but the harness ran Core tests rather than only QA\n