### PR TITLE
Remove redundant rendered API docs QA override

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, GlobalSensitivity, Test
 run_qa(
     GlobalSensitivity;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; ambiguities = (; recursive = false)),
     ei_kwargs = (;
         # OtherPkg-non-public names accessed qualified (e.g. `Random.default_rng`);


### PR DESCRIPTION
Removes the repository-specific `api_docs_kwargs = (; rendered = true)` override from `test/qa/qa.jl`.

SciMLTesting 2.1 performs the rendered API documentation check by default, so the explicit option is redundant. This keeps the package on the shared QA behavior without changing public API docs or package code.

Validation:
- `julia +1.10 --project=test/qa ... include("test/qa/qa.jl")`: 15 passed, 1 pre-existing broken
- `julia +1.12 --project=. -e "import Pkg; Pkg.test()"`: passed
- Runic CLI check: passed

Ignore until reviewed by @ChrisRackauckas.