### PR TITLE
Bump GlobalSensitivity to v2.12.4 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GlobalSensitivity"
 uuid = "af5da776-676b-467e-8baf-acd8249e4f0f"
-version = "2.12.3"
+version = "2.12.4"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Releases the unreleased fix on master: Morris results when parameters are unsampled (#252).

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. **No local test run** — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.