### PR TITLE
Migrate strict QA to SciMLTesting 2.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "2.12.4"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 ComplexityMeasures = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 Copulas = "ae264745-0b69-425e-9d9d-cf662c5eec93"
@@ -21,6 +22,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [compat]
+AbstractFFTs = "1"
 Combinatorics = "1"
 ComplexityMeasures = "3.6"
 Copulas = "0.1.22"
@@ -35,7 +37,7 @@ QuasiMonteCarlo = "0.2.3, 0.3"
 Random = "1.10"
 RecursiveArrayTools = "4"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 StableRNGs = "1"
 Statistics = "1.10"
 StatsBase = "0.34.6"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 ComplexityMeasures = "ab4b797d-85ee-42ba-b621-05d793b346a2"
 Copulas = "ae264745-0b69-425e-9d9d-cf662c5eec93"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
@@ -23,10 +25,12 @@ Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [compat]
 AbstractFFTs = "1"
+ADTypes = "1"
 Combinatorics = "1"
 ComplexityMeasures = "3.6"
 Copulas = "0.1.22"
 Distributions = "0.25.87"
+DifferentiationInterface = "0.7"
 FFTW = "1.4.0"
 ForwardDiff = "1.0.1"
 KernelDensity = "0.6.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,9 +13,8 @@ makedocs(
     sitename = "GlobalSensitivity.jl",
     authors = "Vaibhav Kumar Dixit",
     modules = [GlobalSensitivity],
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, doctest = true, checkdocs = :exports, linkcheck = true,
     linkcheck_ignore = [r"https://www.sciencedirect.com/*"],
-    warnonly = [:missing_docs],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/GlobalSensitivity/stable/"

--- a/src/DGSM_sensitivity.jl
+++ b/src/DGSM_sensitivity.jl
@@ -56,11 +56,9 @@ function gsa(f, method::DGSM, distr::AbstractArray; samples::Int, kwargs...)
 
     XX = [rand.(distr) for x in 1:samples]
 
-    #function to evaluate gradient of f wrt x
-    grad(x) = ForwardDiff.gradient(f, x)
-
-    #function to evaluate hessian of f wrt x
-    hess(x) = ForwardDiff.hessian(f, x)
+    ad_backend = AutoForwardDiff()
+    grad(x) = DifferentiationInterface.gradient(f, ad_backend, x)
+    hess(x) = DifferentiationInterface.hessian(f, ad_backend, x)
 
     #Evaluating the derivatives with AD
 

--- a/src/GlobalSensitivity.jl
+++ b/src/GlobalSensitivity.jl
@@ -10,10 +10,22 @@ or precomputed design matrices.
 """
 module GlobalSensitivity
 
-using Statistics, RecursiveArrayTools, LinearAlgebra, Random
-using QuasiMonteCarlo, ForwardDiff, KernelDensity, Trapz
-using FFTW, Distributions, StatsBase
-using Copulas, Combinatorics
+import AbstractFFTs: rfft
+import Combinatorics: permutations
+import Copulas
+import Copulas: GaussianCopula, IndependentCopula, SklarDist, condition
+import Distributions: Distribution, MvNormal, Normal, Uniform, UnivariateDistribution, cdf, pdf
+import FFTW: dct
+import ForwardDiff
+import KernelDensity: kde
+import LinearAlgebra: Symmetric, diag, dot, pinv
+import QuasiMonteCarlo
+import Random
+import Random: AbstractRNG, rand!, randperm, shuffle!
+import RecursiveArrayTools
+import Statistics: cov, mean, quantile, std, var
+import StatsBase: competerank
+import Trapz: trapz
 using ComplexityMeasures: entropy, ValueHistogram, StateSpaceSet
 
 abstract type GSAMethod end

--- a/src/GlobalSensitivity.jl
+++ b/src/GlobalSensitivity.jl
@@ -11,15 +11,18 @@ or precomputed design matrices.
 module GlobalSensitivity
 
 import AbstractFFTs: rfft
+import ADTypes: AutoForwardDiff
 import Combinatorics: permutations
 import Copulas
 import Copulas: GaussianCopula, IndependentCopula, SklarDist, condition
 import Distributions: Distribution, MvNormal, Normal, Uniform, UnivariateDistribution, cdf, pdf
+import DifferentiationInterface
 import FFTW: dct
 import ForwardDiff
 import KernelDensity: kde
 import LinearAlgebra: Symmetric, diag, dot, pinv
 import QuasiMonteCarlo
+import QuasiMonteCarlo: generate_design_matrices, sample
 import Random
 import Random: AbstractRNG, rand!, randperm, shuffle!
 import RecursiveArrayTools

--- a/src/delta_sensitivity.jl
+++ b/src/delta_sensitivity.jl
@@ -167,7 +167,7 @@ function gsa(
     )
     lb = [float(i[1]) for i in p_range]
     ub = [float(i[2]) for i in p_range]
-    X = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+    X = sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
 
     if batch
         Y = f(X)

--- a/src/easi_sensitivity.jl
+++ b/src/easi_sensitivity.jl
@@ -161,7 +161,7 @@ end
 function gsa(f, method::EASI, p_range; samples, batch = false)
     lb = [float(i[1]) for i in p_range]
     ub = [float(i[2]) for i in p_range]
-    X = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+    X = sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
 
     Y = if batch
         f(X)

--- a/src/fractional_factorial_sensitivity.jl
+++ b/src/fractional_factorial_sensitivity.jl
@@ -33,8 +33,6 @@ Code based on the theory presetned in:
 Saltelli, A. (2008). Global sensitivity analysis: The primer. Chichester: Wiley, pp. 71-76.
 """
 
-using LinearAlgebra
-
 function _recursive_hadamard(k::Integer)
     """
     Generate a hadamard matrix via recursion.

--- a/src/morris_sensitivity.jl
+++ b/src/morris_sensitivity.jl
@@ -1,10 +1,10 @@
-@doc raw"""
+"""
 
     Morris(; p_steps::Array{Int, 1} = Int[], relative_scale::Bool = false,
                 num_trajectory::Int = 10,
                 total_num_trajectory::Int = 5 * num_trajectory, len_design_mat::Int = 10)
 
-- `p_steps`: Vector of ``\Delta`` for the step sizes in each direction. Required.
+- `p_steps`: Vector of ``\\Delta`` for the step sizes in each direction. Required.
 - `relative_scale`: The elementary effects are calculated with the assumption that the parameters lie in the range [0,1] but as this is not always the case scaling is used to get more informative, scaled effects. Defaults to false.
 - `total_num_trajectory`, `num_trajectory`: The total number of design matrices that are generated, out of which num_trajectory matrices with the highest spread are used in calculation.
 - `len_design_mat`: The size of a design matrix.
@@ -19,7 +19,7 @@ which are calculated by measuring the perturbation in the output of the
 model on changing one parameter.
 
 ```math
-EE_i = \frac{f(x_1,x_2,..x_i+ \Delta,..x_k) - y}{\Delta}
+EE_i = \\frac{f(x_1,x_2,..x_i+ \\Delta,..x_k) - y}{\\Delta}
 ```
 
 These are evaluated at various points in the input chosen such that a wide

--- a/src/mutual_information_sensitivity.jl
+++ b/src/mutual_information_sensitivity.jl
@@ -1,4 +1,4 @@
-@doc raw"""
+"""
 
 MutualInformation(; n_bootstraps = 1000, conf_level = 0.95)
 
@@ -13,12 +13,12 @@ the output uncertainty is quantified by the entropy of the output distribution, 
 given by:
 
 ```math
-H(Y) = -\sum_y p(y) \log p(y)
+H(Y) = -\\sum_y p(y) \\log p(y)
 ```
 Where ``p(y)`` is the probability density function of the output ``Y``. By fixing an input ``X_i``, the conditional entropy of the output ``Y`` is given by:
 
 ```math
-H(Y|X_i) = -\sum_{x} p(x) H(Y|X_i = x)
+H(Y|X_i) = -\\sum_{x} p(x) H(Y|X_i = x)
 ```
 
 The mutual information between the input ``X_i`` and the output ``Y`` is then given by:
@@ -30,11 +30,11 @@ I(X_i;Y) = H(Y) - H(Y|X_i) = H(X) + H(Y) - H(X,Y)
 Where ``H(X,Y)`` is the joint entropy of the input and output. The mutual information can be used to calculate the sensitivity indices of the input parameters. 
 
 ### Sensitivity Indices
-The sensitivity indices are calculated as the mutual information between the input ``X_i`` and the output ``Y`` where the ``\alpha`` quantile of
+The sensitivity indices are calculated as the mutual information between the input ``X_i`` and the output ``Y`` where the ``\\alpha`` quantile of
 null distribution of the output is subtracted from the mutual information:
 
 ```math
-S_{1,i} = I(X_i;Y) - Q(I(X_i; Y_\text{null}), \alpha)
+S_{1,i} = I(X_i;Y) - Q(I(X_i; Y_\\text{null}), \\alpha)
 ```
 
 Using mutual information for sensitivity analysis is introduced in Lüdtke et al. (2007)[^1] and also present in Datseris & Parlitz (2022)[^2]. 

--- a/src/mutual_information_sensitivity.jl
+++ b/src/mutual_information_sensitivity.jl
@@ -137,7 +137,7 @@ function gsa(f, method::MutualInformation, p_range; samples, batch = false)
     lb = [float(i[1]) for i in p_range]
     ub = [float(i[2]) for i in p_range]
 
-    X = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+    X = sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
 
     if batch
         Y = f(X)

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,7 +1,7 @@
 # Precompilation workload for GlobalSensitivity.jl
 # This file precompiles common code paths to improve TTFX (Time To First X)
 
-using PrecompileTools
+import PrecompileTools: @compile_workload, @setup_workload
 
 @setup_workload begin
     # Minimal test function (Ishigami-like)

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -17,7 +17,7 @@ import PrecompileTools: @compile_workload, @setup_workload
     @compile_workload begin
         # Precompile Sobol method (most common)
         # Use small sample size to keep precompilation time reasonable
-        _A, _B = QuasiMonteCarlo.generate_design_matrices(
+        _A, _B = generate_design_matrices(
             64, _precompile_lb, _precompile_ub,
             QuasiMonteCarlo.SobolSample(), 2
         )
@@ -31,7 +31,7 @@ import PrecompileTools: @compile_workload, @setup_workload
         )
 
         # Precompile RegressionGSA method (matrix-based API)
-        _X_reg = QuasiMonteCarlo.sample(64, _precompile_lb, _precompile_ub, QuasiMonteCarlo.SobolSample())
+        _X_reg = sample(64, _precompile_lb, _precompile_ub, QuasiMonteCarlo.SobolSample())
         _Y_reg = reshape([_precompile_f(_X_reg[:, j]) for j in 1:64], 1, 64)
         _reg_result = gsa(_X_reg, _Y_reg, RegressionGSA())
 

--- a/src/rbd-fast_sensitivity.jl
+++ b/src/rbd-fast_sensitivity.jl
@@ -62,8 +62,6 @@ and
     Reliability Engineering and System Safety, 91:6, 717-727
 """
 
-using FFTW, Random, Statistics, StatsBase, Distributions
-
 function gsa(
         f, method::RBDFAST; num_params, samples,
         rng::AbstractRNG = Random.default_rng(), batch = false, kwargs...

--- a/src/regression_sensitivity.jl
+++ b/src/regression_sensitivity.jl
@@ -1,4 +1,4 @@
-@doc raw"""
+"""
 
     RegressionGSA(; rank::Bool = false)
 
@@ -22,26 +22,26 @@ The measures provided for this analysis by us in GlobalSensitivity.jl are
   a) Pearson Correlation Coefficient:
 
 ```math
-r = \frac{\sum_{i=1}^{n} (x_i - \overline{x})(y_i - \overline{y})}{\sqrt{\sum_{i=1}^{n} (x_i - \overline{x})^2(y_i - \overline{y})^2}}
+r = \\frac{\\sum_{i=1}^{n} (x_i - \\overline{x})(y_i - \\overline{y})}{\\sqrt{\\sum_{i=1}^{n} (x_i - \\overline{x})^2(y_i - \\overline{y})^2}}
 ```
 
   b) Standard Regression Coefficient (SRC):
 
 ```math
-SRC_j = \beta_{j} \sqrt{\frac{Var(X_j)}{Var(Y)}}
+SRC_j = \\beta_{j} \\sqrt{\\frac{Var(X_j)}{Var(Y)}}
 ```
 
-where ``\beta_j`` is the linear regression coefficient associated to ``X\_j``. This is also known
+where ``\\beta_j`` is the linear regression coefficient associated to ``X\\_j``. This is also known
 as a sigma-normalized derivative.
 
   c) Partial Correlation Coefficient (PCC):
 
 ```math
-PCC_j = \rho(X_j - \hat{X_{-j}},Y_j - \hat{Y_{-j}})
+PCC_j = \\rho(X_j - \\hat{X_{-j}},Y_j - \\hat{Y_{-j}})
 ```
 
-where ``\hat{X_{-j}}`` is the prediction of the linear model, expressing ``X_{j}``
-with respect to the other inputs and ``\hat{Y_{-j}}`` is the prediction of the
+where ``\\hat{X_{-j}}`` is the prediction of the linear model, expressing ``X_{j}``
+with respect to the other inputs and ``\\hat{Y_{-j}}`` is the prediction of the
 linear model where ``X_j`` is absent. PCC measures the sensitivity of ``Y`` to
 ``X_j`` when the effects of the other inputs have been canceled.
 

--- a/src/regression_sensitivity.jl
+++ b/src/regression_sensitivity.jl
@@ -148,7 +148,7 @@ end
 function gsa(f, method::RegressionGSA, p_range::AbstractVector; samples::Int, batch = false)
     lb = [float(i[1]) for i in p_range]
     ub = [float(i[2]) for i in p_range]
-    X = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
+    X = sample(samples, lb, ub, QuasiMonteCarlo.SobolSample())
     desol = false
 
     if batch

--- a/src/rsa_sensitivity.jl
+++ b/src/rsa_sensitivity.jl
@@ -1,4 +1,4 @@
-@doc raw"""
+"""
 
     RSA(; n_dummy_parameters::Int = 10, acceptance_threshold::Union{Function, Real} = mean)
 
@@ -9,11 +9,11 @@
 ## Method Details
 
 The RSA (Regional Sensitivity Analysis) method[^1] is a monte-carlo based technique for performing nonparametric global sensitivity analysis. The method is based on the Kolmogorov-Smirnov (KS) test, which is a nonparametric test of the equality of continuous, 
-one-dimensional probability distributions. Each result of a monte-carlo simulation is either classified as behavior (``B``) or non-behavior (``\bar{B}``). For each parameter ``i``, 
-the cumulative distributions of the behavior and non-behavior outputs are determined as ``F_{i}`` and ``\bar{F}_{i}``, respectively. The sensitivity for each parameter ``i`` is then given by:
+one-dimensional probability distributions. Each result of a monte-carlo simulation is either classified as behavior (``\\bar{B}``). For each parameter ``i``,
+the cumulative distributions of the behavior and non-behavior outputs are determined as ``F_{i}`` and ``\\bar{F}_{i}``, respectively. The sensitivity for each parameter ``i`` is then given by:
 
 ```math
-S_{i} = \sup_{j} |F_{i,j} - (1 - F_{i,j})|
+S_{i} = \\sup_{j} |F_{i,j} - (1 - F_{i,j})|
 ```
 
 where ``F_{i,j}`` is sample ``j`` of the cumulative distribution of the sensitivity output for parameter ``i``.

--- a/src/rsa_sensitivity.jl
+++ b/src/rsa_sensitivity.jl
@@ -118,7 +118,7 @@ function gsa(f, method::RSA, p_range; samples, batch = false)
     # add dummy parameters
     lb = [lb; repeat([typeof(lb[1])(0.0)], method.n_dummy_parameters)]
     ub = [ub; repeat([typeof(ub[1])(1.0)], method.n_dummy_parameters)]
-    X = QuasiMonteCarlo.sample(samples, lb, ub, QuasiMonteCarlo.LatinHypercubeSample())
+    X = sample(samples, lb, ub, QuasiMonteCarlo.LatinHypercubeSample())
 
     X̂ = X[1:length(lb), :]
     if batch

--- a/src/shapley_sensitivity.jl
+++ b/src/shapley_sensitivity.jl
@@ -1,4 +1,4 @@
-@doc raw"""
+"""
 
     Shapley(n_perms, n_var, n_outer, n_inner)
 

--- a/src/sobol_sensitivity.jl
+++ b/src/sobol_sensitivity.jl
@@ -1,4 +1,4 @@
-@doc raw"""
+"""
 
     Sobol(; order = [0, 1], nboot = 1, conf_level = 0.95)
 
@@ -15,14 +15,14 @@ but also gives a way to quantify the affect and sensitivity from
 the interaction between the parameters.
 
 ```math
- Y = f_0+ \sum_{i=1}^d f_i(X_i)+ \sum_{i < j}^d f_{ij}(X_i,X_j) ... + f_{1,2...d}(X_1,X_2,..X_d)
+ Y = f_0+ \\sum_{i=1}^d f_i(X_i)+ \\sum_{i < j}^d f_{ij}(X_i,X_j) ... + f_{1,2...d}(X_1,X_2,..X_d)
 ```
 
 ```math
- Var(Y) = \sum_{i=1}^d V_i + \sum_{i < j}^d V_{ij} + ... + V_{1,2...,d}
+ Var(Y) = \\sum_{i=1}^d V_i + \\sum_{i < j}^d V_{ij} + ... + V_{1,2...,d}
 ```
 
-The Sobol Indices are "order"ed, the first order indices given by ``S_i = \frac{V_i}{Var(Y)}``
+The Sobol Indices are "order"ed, the first order indices given by ``S_i = \\frac{V_i}{Var(Y)}``
 the contribution to the output variance of the main effect of `` X_i ``. Therefore, it
 measures the effect of varying `` X_i `` alone, but averaged over variations
 in other input parameters. It is standardized by the total variance to provide a fractional contribution.

--- a/src/sobol_sensitivity.jl
+++ b/src/sobol_sensitivity.jl
@@ -405,7 +405,7 @@ function gsa_sobol_all_y_analysis(
 end
 
 function gsa(f, method::Sobol, p_range::AbstractVector; samples, kwargs...)
-    AB = QuasiMonteCarlo.generate_design_matrices(
+    AB = generate_design_matrices(
         samples, [float(i[1]) for i in p_range],
         [float(i[2]) for i in p_range],
         QuasiMonteCarlo.SobolSample(),

--- a/test/eFAST_method.jl
+++ b/test/eFAST_method.jl
@@ -1,4 +1,5 @@
 using GlobalSensitivity, QuasiMonteCarlo, Test, OrdinaryDiffEq, Distributions
+using StableRNGs: StableRNG
 
 function ishi_batch(X)
     A = 7
@@ -25,10 +26,13 @@ end
 lb = -ones(4) * π
 ub = ones(4) * π
 
-res1 = gsa(ishi, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000)
+res1 = gsa(
+    ishi, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000,
+    rng = StableRNG(42)
+)
 res2 = gsa(
     ishi_batch, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000,
-    batch = true
+    batch = true, rng = StableRNG(42)
 )
 
 @test res1.S1 ≈ [0.307599 0.442412 3.0941e-25 3.42372e-28] atol = 1.0e-4
@@ -37,10 +41,13 @@ res2 = gsa(
 @test res1.ST ≈ [0.556244 0.446861 0.239259 0.027099] atol = 1.0e-4
 @test res2.ST ≈ [0.556244 0.446861 0.239259 0.027099] atol = 1.0e-4
 
-res1 = gsa(ishi, eFAST(), [Uniform(lb[i], ub[i]) for i in 1:4], samples = 15000)
+res1 = gsa(
+    ishi, eFAST(), [Uniform(lb[i], ub[i]) for i in 1:4], samples = 15000,
+    rng = StableRNG(42)
+)
 res2 = gsa(
     ishi_batch, eFAST(), [Uniform(lb[i], ub[i]) for i in 1:4], samples = 15000,
-    batch = true
+    batch = true, rng = StableRNG(42)
 )
 
 @test res1.S1 ≈ [0.307599 0.442412 3.0941e-25 3.42372e-28] atol = 1.0e-4
@@ -49,10 +56,12 @@ res2 = gsa(
 @test res1.ST ≈ [0.556244 0.446861 0.239259 0.027099] atol = 1.0e-4
 @test res2.ST ≈ [0.556244 0.446861 0.239259 0.027099] atol = 1.0e-4
 
-res1 = gsa(ishi, eFAST(), [Normal() for i in 1:4], samples = 15000)
+res1 = gsa(
+    ishi, eFAST(), [Normal() for i in 1:4], samples = 15000, rng = StableRNG(42)
+)
 res2 = gsa(
     ishi_batch, eFAST(), [Normal() for i in 1:4], samples = 15000,
-    batch = true
+    batch = true, rng = StableRNG(42)
 )
 
 @test res1.S1 ≈ [0.10140099594185588 0.7556923800497227 1.5688549609448593e-6 3.0948866309361236e-7] atol = 1.0e-1
@@ -61,10 +70,13 @@ res2 = gsa(
 @test res1.ST ≈ [0.1538586603409846 0.84687840567574 0.12089782535494331 0.101911083206915] atol = 1.0e-1
 @test res2.ST ≈ [0.15130306101221003 0.8455036299750917 0.12229080086326627 0.15148183125412495] atol = 1.0e-1
 
-res1 = gsa(linear, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000)
+res1 = gsa(
+    linear, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000,
+    rng = StableRNG(42)
+)
 res2 = gsa(
     linear_batch, eFAST(), [[lb[i], ub[i]] for i in 1:4], batch = true,
-    samples = 15000
+    samples = 15000, rng = StableRNG(42)
 )
 
 @test res1.S1 ≈ [0.997504 0.000203575 2.1599e-10 2.18296e-10] atol = 1.0e-4
@@ -87,10 +99,13 @@ function ishi_linear_batch(X)
     return vcat(X1', X2')
 end
 
-res1 = gsa(ishi_linear, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000)
+res1 = gsa(
+    ishi_linear, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000,
+    rng = StableRNG(42)
+)
 res2 = gsa(
     ishi_linear_batch, eFAST(), [[lb[i], ub[i]] for i in 1:4], samples = 15000,
-    batch = true
+    batch = true, rng = StableRNG(42)
 )
 
 # Now both tests together
@@ -132,4 +147,7 @@ f1 = let prob = prob, t = t
     end
 end
 
-m = gsa(f1, eFAST(), [[1, 5], [1, 5], [1, 5], [1, 5]], samples = 1000)
+m = gsa(
+    f1, eFAST(), [[1, 5], [1, 5], [1, 5], [1, 5]], samples = 1000,
+    rng = StableRNG(42)
+)

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -124,6 +124,16 @@ end
         res = gsa(f_linear, DGSM(), dist, samples = 200)
         @test res.a isa Vector
         @test length(res.a) == 3
+
+        f_quadratic(x) = x[1]^2 + x[1] * x[2] + x[2]^2
+        crossed = gsa(
+            f_quadratic,
+            DGSM(crossed = true),
+            [Uniform(-1, 1), Uniform(-1, 1)],
+            samples = 200
+        )
+        @test size(crossed.crossed) == (2, 2)
+        @test all(isfinite, crossed.crossed)
     end
 
     @testset "Direct X,Y interface" begin

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,6 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,23 +1,3 @@
 using SciMLTesting, GlobalSensitivity, Test
-run_qa(
-    GlobalSensitivity;
-    explicit_imports = true,
-    aqua_kwargs = (; ambiguities = (; recursive = false)),
-    ei_kwargs = (;
-        # OtherPkg-non-public names accessed qualified (e.g. `Random.default_rng`);
-        # de-facto public, just not yet declared `public` upstream.
-        all_qualified_accesses_are_public = (;
-            ignore = (
-                :default_rng,              # Random
-                :generate_design_matrices, # QuasiMonteCarlo
-                :sample,                   # QuasiMonteCarlo
-                :gradient,                 # ForwardDiff
-                :hessian,                  # ForwardDiff
-            ),
-        ),
-    ),
-    # Heavy `using Statistics/Distributions/...` implicit imports; making each
-    # explicit is a large, mechanical refactor — tracked in
-    # https://github.com/SciML/GlobalSensitivity.jl/issues/245
-    ei_broken = (:no_implicit_imports,)
-)
+
+run_qa(GlobalSensitivity)


### PR DESCRIPTION
## Summary
- Require SciMLTesting 2.4 and use its strict default QA configuration.
- Replace wrapper docstrings with definition-site docstrings, complete explicit imports, and add a direct AbstractFFTs dependency.
- Enable exported-doc and doctest checks in Documenter.

## Validation
- `GROUP=Core Pkg.test()` passed after the explicit Copulas import repair.
- Full Documenter build, doctests, exported-doc checks, and link checking passed.
- SciMLTesting 2.4 strict QA passes 19/20 checks. The remaining check correctly rejects `QuasiMonteCarlo.sample`, `QuasiMonteCarlo.generate_design_matrices`, `ForwardDiff.gradient`, and `ForwardDiff.hessian`, which their owners do not currently declare public. No QA exception is retained.
- Runic and `git diff --check` passed.

Ignore until reviewed by @ChrisRackauckas.