### PR TITLE
Bump GlobalSensitivity to v2.12.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GlobalSensitivity"
 uuid = "af5da776-676b-467e-8baf-acd8249e4f0f"
-version = "2.12.4"
+version = "2.12.5"
 authors = ["Vaibhavdixit02 <vaibhavyashdixit@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `GlobalSensitivity` **v2.12.4 → v2.12.5** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Remove redundant rendered API docs QA override (#254) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)