### PR TITLE
Fix docs build: import EnsembleProblem/EnsembleThreads in shapley.md

### DIFF
--- a/docs/src/tutorials/shapley.md
+++ b/docs/src/tutorials/shapley.md
@@ -19,6 +19,7 @@ As the first step let's generate the dataset.
 ```@example shapley
 using GlobalSensitivity, OrdinaryDiffEq, Flux, SciMLSensitivity, LinearAlgebra
 using Optimization, OptimizationOptimisers, Distributions, Copulas, CairoMakie
+using SciMLBase: EnsembleProblem, EnsembleThreads
 
 u0 = [2.0f0; 0.0f0]
 datasize = 30


### PR DESCRIPTION
## Summary

Fixes the failing Documentation CI build (see [failing run](https://github.com/SciML/GlobalSensitivity.jl/actions/runs/32931814104)).

**Root cause:** The `@example shapley` block in `docs/src/tutorials/shapley.md` uses `EnsembleProblem` and `EnsembleThreads` but never imports them. Other tutorials (`parallelized_gsa.md`, `juliacon21.md`) explicitly import these via `using SciMLBase: EnsembleProblem, EnsembleThreads`, but `shapley.md` was missing this import. With `SciMLBase` v3, these names are no longer transitively brought into scope through `OrdinaryDiffEq`'s re-exports, so the doc build fails with:

```
UndefVarError: `EnsembleThreads` not defined in `Main.__atexample__named__shapley`
```

which then cascades into `UndefVarError: shapley_effects not defined` in the subsequent example blocks that depend on it, terminating the `makedocs` build with a `[:example_block]` error.

**Fix:** Add the missing `using SciMLBase: EnsembleProblem, EnsembleThreads` import to the first code block of `shapley.md`, matching the pattern already used elsewhere in the docs.

## Test plan

- Instantiated `docs/` environment locally and reproduced the exact failure (`UndefVarError: EnsembleThreads not defined`) with the import missing.
- Applied the fix and ran a scoped smoke test replicating the `shapley.md` example code (same imports, ODE/NN setup, `batched_loss_n_ode`, and a `gsa(..., Shapley(...))` call with reduced `n_perms`/`n_var`/`n_outer` for speed) — confirms `EnsembleProblem`/`EnsembleThreads` resolve correctly and `shapley_effects` computes successfully end-to-end.
- Did not run the full `docs/make.jl` (the untouched tutorial as written trains a Neural ODE for 300 iterations and computes Shapley effects with `n_outer` up to 100, which is prohibitively slow for local verification), but the fix is a one-line addition identical to the working pattern used in two other tutorials in this same repo.

Made with [Cursor](https://cursor.com)