### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/sobol_sensitivity.jl
+++ b/src/sobol_sensitivity.jl
@@ -219,20 +219,20 @@ function gsa_sobol_all_y_analysis(
                     Eᵢs,
                     [
                         (
-                                sum(fA .^ 2 + fAⁱ[k] .^ 2) ./ (2n) .-
+                            sum(fA .^ 2 + fAⁱ[k] .^ 2) ./ (2n) .-
                                 (sum(fA + fAⁱ[k]) ./ (2n)) .^ 2
-                            ) * (
-                                1.0 .-
+                        ) * (
+                            1.0 .-
                                 (
-                                    1 / n .* sum(fA .* fAⁱ[k])
+                                1 / n .* sum(fA .* fAⁱ[k])
                                     .-
                                     (1 / n .* sum((fA .+ fAⁱ[k]) ./ 2)) .^ 2
-                                ) ./
+                            ) ./
                                 (
-                                    1 / n .* sum((fA .^ 2 .+ fAⁱ[k] .^ 2) ./ 2) -
+                                1 / n .* sum((fA .^ 2 .+ fAⁱ[k] .^ 2) ./ 2) -
                                     (1 / n .* sum((fA .+ fAⁱ[k]) ./ 2)) .^ 2
-                                )
                             )
+                        )
                             for k in 1:d
                     ]
                 )
@@ -299,19 +299,19 @@ function gsa_sobol_all_y_analysis(
                         hcat,
                         [
                             (
-                                    sum(fA .^ 2 + fAⁱ[k] .^ 2, dims = 2) ./ (2n) .-
+                                sum(fA .^ 2 + fAⁱ[k] .^ 2, dims = 2) ./ (2n) .-
                                     (sum(fA + fAⁱ[k], dims = 2) ./ (2n)) .^ 2
-                                ) .* (
-                                    1.0 .-
+                            ) .* (
+                                1.0 .-
                                     (
-                                        1 / n .* sum(fA .* fAⁱ[k], dims = 2) .-
+                                    1 / n .* sum(fA .* fAⁱ[k], dims = 2) .-
                                         (1 / n * sum((fA .+ fAⁱ[k]) ./ 2, dims = 2)) .^ 2
-                                    ) ./
+                                ) ./
                                     (
-                                        1 / n .* sum((fA .^ 2 .+ fAⁱ[k] .^ 2) ./ 2, dims = 2) .-
+                                    1 / n .* sum((fA .^ 2 .+ fAⁱ[k] .^ 2) ./ 2, dims = 2) .-
                                         (1 / n * sum((fA .+ fAⁱ[k]) ./ 2, dims = 2)) .^ 2
-                                    )
-                                ) for k in 1:d
+                                )
+                            ) for k in 1:d
                         ]
                     )
                 )


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `c440790c4308`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos src/sobol_sensitivity.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
QA/qa.jl: 20 passed; package tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Shapley method 13/13 and Sobol method 41/41 passed; package tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)