### PR TITLE
Require LatticeRules 0.0.2 (32-bit LatticeRule32)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [compat]
+LatticeRules = "0.0.2"
 AbstractFFTs = "1"
 ADTypes = "1"
 Combinatorics = "1"
@@ -50,6 +51,7 @@ Trapz = "2"
 julia = "1.10"
 
 [extras]
+LatticeRules = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -57,4 +59,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "Test", "StableRNGs"]
+test = ["LatticeRules", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "Test", "StableRNGs"]


### PR DESCRIPTION
## Summary
Force LatticeRules ≥0.0.2 so QuasiMonteCarlo LatticeRuleSample precompile works on i686 (0.0.1 rejects `typemax(UInt32)+1`-style bounds).

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)