### PR TITLE
Require QuasiMonteCarlo 0.4.3 for 32-bit LatticeRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 
 [compat]
-LatticeRules = "0.0.2"
 AbstractFFTs = "1"
 ADTypes = "1"
 Combinatorics = "1"
@@ -38,7 +37,7 @@ KernelDensity = "0.6.4"
 LinearAlgebra = "1.10"
 OrdinaryDiffEq = "7"
 PrecompileTools = "1.2.1"
-QuasiMonteCarlo = "0.3, 0.4"
+QuasiMonteCarlo = "0.4.3"
 Random = "1.10"
 RecursiveArrayTools = "4"
 SafeTestsets = "0.1"
@@ -51,7 +50,6 @@ Trapz = "2"
 julia = "1.10"
 
 [extras]
-LatticeRules = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -59,4 +57,4 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LatticeRules", "OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "Test", "StableRNGs"]
+test = ["OrdinaryDiffEq", "SafeTestsets", "SciMLTesting", "Test", "StableRNGs"]


### PR DESCRIPTION
## Summary
- Remove ineffective/unsatisfiable LatticeRules 0.0.2 test-extra force.
- Bump QuasiMonteCarlo to 0.4.3 (pulls LatticeRules 0.0.2).

## Test plan
- [ ] x86 Core green (or parity with x64)


Made with [Cursor](https://cursor.com)