### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs,Distributions"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,54 @@
+using GlobalSensitivity, BenchmarkTools
+using StableRNGs, Distributions
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+# Ishigami test function (standard GSA benchmark)
+ishi(X) = sin(X[1]) + 7 * sin(X[2])^2 + 0.1 * X[3]^4 * sin(X[1])
+p_range = fill([-π, π], 3)
+
+# Morris linear test
+A_m = [1.0 0.0; 3.0 0.0; 5.0 0.0; 7.0 0.0]
+f_morris(x) = A_m * vec(x)
+
+# =============================================================================
+# Variance-based methods
+# =============================================================================
+
+SUITE["sobol"] = BenchmarkGroup()
+
+SUITE["sobol"]["ishigami"] = @benchmarkable gsa(
+    $ishi, Sobol(), $p_range; samples = 2000
+)
+SUITE["sobol"]["efast"] = @benchmarkable gsa(
+    $ishi, eFAST(), $p_range; num_harmonics = 6, samples = 500
+)
+
+# =============================================================================
+# Morris method
+# =============================================================================
+
+SUITE["morris"] = BenchmarkGroup()
+
+SUITE["morris"]["linear"] = @benchmarkable gsa(
+    $f_morris,
+    Morris(p_steps = [10, 10], total_num_trajectory = 500, num_trajectory = 100),
+    [[1, 5], [1, 5]]
+)
+
+# =============================================================================
+# Regression / DGSM
+# =============================================================================
+
+SUITE["other"] = BenchmarkGroup()
+
+SUITE["other"]["regression"] = @benchmarkable gsa(
+    $ishi, RegressionGSA(), $p_range; samples = 2000
+)
+SUITE["other"]["dgsm"] = @benchmarkable gsa(
+    $ishi, DGSM(), [Uniform(-π, π) for _ in 1:3]; samples = 500
+)
+SUITE["other"]["delta_moment"] = @benchmarkable gsa(
+    $ishi, DeltaMoment(), $p_range; samples = 1000
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~60s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~60s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md